### PR TITLE
Ci/security scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,3 +243,37 @@ jobs:
                       fi
                   done
                   echo "All seven optional modules absent from the resolved project."
+
+    # ────────────────────────────────────────────────────────────────
+    # Secret scan
+    # ────────────────────────────────────────────────────────────────
+    # SECURITY.md promises no credentials in logs; this covers the other half, the repository
+    # itself. The broker writes its token to broker.pid and client configs carry server URLs, so
+    # a stray runtime file is the realistic way one lands in a commit.
+    #
+    # The docker image rather than gitleaks-action: the action wants a licence key for
+    # organisation-owned repos, and this needs neither a key nor a secret to run on forks.
+    # ────────────────────────────────────────────────────────────────
+    secrets:
+        name: Secret Scan
+        runs-on: ubuntu-latest
+        # Advisory until one green run is observed: this scans all history, so a finding from an
+        # old commit would block every PR before anyone could rotate and allowlist it.
+        # Remove this line after that run.
+        continue-on-error: true
+        permissions:
+            contents: read
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  # detect walks history, so a shallow clone would scan almost nothing.
+                  fetch-depth: 0
+
+            # --redact keeps a hit from printing the secret into a public build log, which would
+            # publish the thing the scan just found.
+            - name: Scan for committed secrets
+              run: |
+                  docker run --rm -v "$PWD:/repo" zricethezav/gitleaks:latest \
+                      detect --source=/repo --no-banner --redact --verbose

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+    schedule:
+        # Weekly, so a new query release finds old code without waiting for a push.
+        - cron: "0 3 * * 1"
+    workflow_dispatch:
+
+jobs:
+    analyze:
+        name: Analyze C#
+        runs-on: ubuntu-latest
+        permissions:
+            security-events: write
+            contents: read
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            # keepalive-broker.cs.txt is the broker's whole source: it owns the client-facing port,
+            # runs outside Unity's AppDomain and outlives the editor. The .txt extension keeps Unity
+            # from compiling it into the package, and it also keeps every C# extractor from reading
+            # it, so without this step CodeQL passes having never looked at the most exposed file in
+            # the repository.
+            - name: Stage the runtime-compiled broker for analysis
+              run: |
+                  src="Editor/MCP/Server/Broker/keepalive-broker.cs.txt"
+                  if [ ! -f "$src" ]; then
+                      echo "::error::$src not found. It moved or was renamed, and the broker would drop out of this scan without failing it. Update this step."
+                      exit 1
+                  fi
+                  mkdir -p codeql-staging
+                  cp "$src" codeql-staging/keepalive-broker.cs
+                  echo "Staged $(wc -l < codeql-staging/keepalive-broker.cs) lines of broker source."
+
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v3
+              with:
+                  languages: csharp
+                  # No Unity license on this runner, so nothing here can be built. The extractor
+                  # reads the sources directly instead.
+                  build-mode: none
+                  queries: security-extended
+
+            - name: Analyze
+              uses: github/codeql-action/analyze@v3
+              with:
+                  category: /language:csharp

--- a/Editor/MCP/Server/Broker/keepalive-broker.cs.txt
+++ b/Editor/MCP/Server/Broker/keepalive-broker.cs.txt
@@ -214,6 +214,18 @@ namespace KitWright.UnityMcp.Broker
                 return;
             }
 
+            // Same DNS-rebinding defense that does not depend on Origin: a rebound name resolves to
+            // this loopback port but arrives with a non-loopback Host. This is the client-facing port.
+            string host;
+            headers.TryGetValue("host", out host);
+            if (!IsValidHost(host))
+            {
+                Log("refused request with host " + host);
+                WriteResponse(stream, 403, "Forbidden", "text/plain", BrokerHeaderLine(), "Host not allowed");
+                SafeClose(client);
+                return;
+            }
+
             LastActivityMs = NowMs();
 
             if (method == "GET" && path.StartsWith("/_kitwright/broker/health", StringComparison.Ordinal))
@@ -1010,6 +1022,29 @@ namespace KitWright.UnityMcp.Broker
         {
             return string.IsNullOrEmpty(origin) ||
                    (Uri.TryCreate(origin, UriKind.Absolute, out var uri) && uri.IsLoopback);
+        }
+
+        private static bool IsValidHost(string host)
+        {
+            if (string.IsNullOrEmpty(host))
+                return true; // Absent Host (HTTP/1.0 / native client); the loopback bind already limits reach.
+
+            host = host.Trim();
+            if (host.StartsWith("["))
+            {
+                var end = host.IndexOf(']');
+                host = end > 0 ? host.Substring(1, end - 1) : host;
+            }
+            else
+            {
+                var colon = host.IndexOf(':');
+                if (colon >= 0)
+                    host = host.Substring(0, colon);
+            }
+
+            return string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(host, "127.0.0.1", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(host, "::1", StringComparison.OrdinalIgnoreCase);
         }
 
         // Mirrors HttpMCPTransport.ExtractPin: this process cannot reference the package assembly.

--- a/Editor/MCP/Server/Broker/keepalive-broker.cs.txt
+++ b/Editor/MCP/Server/Broker/keepalive-broker.cs.txt
@@ -981,7 +981,22 @@ namespace KitWright.UnityMcp.Broker
         {
             string value;
             return headers.TryGetValue(TokenHeader.ToLowerInvariant(), out value) &&
-                   string.Equals(value, Token, StringComparison.Ordinal);
+                   FixedTimeEquals(value, Token);
+        }
+
+        // string.Equals returns on the first differing char, so its timing tells a caller how much
+        // of the token it already guessed. Mono's 4.5 profile compiles this broker and has no
+        // CryptographicOperations.FixedTimeEquals, hence the loop.
+        private static bool FixedTimeEquals(string candidate, string expected)
+        {
+            if (candidate == null || expected == null || candidate.Length != expected.Length)
+                return false;
+
+            var difference = 0;
+            for (int i = 0; i < candidate.Length; i++)
+                difference |= candidate[i] ^ expected[i];
+
+            return difference == 0;
         }
 
         private static string BrokerHeaderLine()

--- a/Editor/MCP/Server/HttpMCPTransport.cs
+++ b/Editor/MCP/Server/HttpMCPTransport.cs
@@ -330,6 +330,14 @@ namespace KitWright.Editor.MCP.Server
                         return;
                     }
 
+                    // DNS-rebinding defense that does not depend on the Origin header: a rebound name
+                    // (evil.example -> 127.0.0.1) arrives with a non-loopback Host. Belt to Origin's suspenders.
+                    if (!IsValidHost(httpRequest.Host))
+                    {
+                        await SendHtmlStatusAsync(stream, HttpStatusCode.Forbidden, "Forbidden", "Host not allowed", ct);
+                        return;
+                    }
+
                     if (httpRequest.Method == "OPTIONS")
                     {
                         await SendOptionsResponseAsync(stream, ct);
@@ -518,6 +526,7 @@ namespace KitWright.Editor.MCP.Server
             var acceptsEventStream = false;
             string sessionId = null;
             string origin = null;
+            string host = null;
             for (var i = 1; i < lines.Length; i++)
             {
                 var separator = lines[i].IndexOf(':');
@@ -544,6 +553,10 @@ namespace KitWright.Editor.MCP.Server
                 {
                     origin = lines[i].Substring(separator + 1).Trim();
                 }
+                else if (string.Equals(name, "Host", StringComparison.OrdinalIgnoreCase))
+                {
+                    host = lines[i].Substring(separator + 1).Trim();
+                }
             }
 
             var bodyStart = headerEnd + 4;
@@ -567,6 +580,7 @@ namespace KitWright.Editor.MCP.Server
                 AcceptsEventStream = acceptsEventStream,
                 SessionId = sessionId,
                 Origin = origin,
+                Host = host,
                 Body = Encoding.UTF8.GetString(bodyBytes, 0, copied)
             };
         }
@@ -659,6 +673,29 @@ namespace KitWright.Editor.MCP.Server
             }
 
             return false;
+        }
+
+        internal static bool IsValidHost(string hostHeader)
+        {
+            if (string.IsNullOrEmpty(hostHeader))
+                return true; // Absent Host (HTTP/1.0 or a native client); the loopback bind already limits reach.
+
+            var host = hostHeader.Trim();
+            if (host.StartsWith("["))
+            {
+                var end = host.IndexOf(']');
+                host = end > 0 ? host.Substring(1, end - 1) : host;
+            }
+            else
+            {
+                var colon = host.IndexOf(':');
+                if (colon >= 0)
+                    host = host.Substring(0, colon);
+            }
+
+            return string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(host, "127.0.0.1", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(host, "::1", StringComparison.OrdinalIgnoreCase);
         }
 
         private Task SendHtmlStatusAsync(NetworkStream stream, HttpStatusCode code, string reason, string message, CancellationToken ct)
@@ -942,6 +979,7 @@ namespace KitWright.Editor.MCP.Server
             public bool AcceptsEventStream { get; set; }
             public string SessionId { get; set; }
             public string Origin { get; set; }
+            public string Host { get; set; }
             public string Body { get; set; }
         }
     }

--- a/Editor/MCP/Server/JsonCodec.cs
+++ b/Editor/MCP/Server/JsonCodec.cs
@@ -239,6 +239,8 @@ namespace KitWright.Editor.MCP.Server
                 int depth = 1; int pos = start + 1;
                 while (pos < json.Length && depth > 0)
                 {
+                    // Skip string bodies so a brace inside a value ("a}b") does not miscount depth.
+                    if (json[pos] == '"') { pos = FindStringEnd(json, pos) + 1; continue; }
                     if (json[pos] == '{') depth++;
                     else if (json[pos] == '}') depth--;
                     pos++;
@@ -251,6 +253,7 @@ namespace KitWright.Editor.MCP.Server
                 int depth = 1; int pos = start + 1;
                 while (pos < json.Length && depth > 0)
                 {
+                    if (json[pos] == '"') { pos = FindStringEnd(json, pos) + 1; continue; }
                     if (json[pos] == '[') depth++;
                     else if (json[pos] == ']') depth--;
                     pos++;

--- a/Editor/MCP/Server/JsonCodec.cs
+++ b/Editor/MCP/Server/JsonCodec.cs
@@ -26,7 +26,16 @@ namespace KitWright.Editor.MCP.Server
             if (obj is bool b)
                 return b ? "true" : "false";
 
-            if (obj is int || obj is long || obj is float || obj is double)
+            if (obj is float || obj is double)
+            {
+                // JSON has no Infinity/NaN literal; Convert.ToString emits one, which is invalid JSON.
+                // Match JSON.stringify and drop non-finite floats to null.
+                var number = Convert.ToDouble(obj, CultureInfo.InvariantCulture);
+                return double.IsNaN(number) || double.IsInfinity(number)
+                    ? "null"
+                    : Convert.ToString(obj, CultureInfo.InvariantCulture);
+            }
+            if (obj is int || obj is long)
                 return Convert.ToString(obj, CultureInfo.InvariantCulture);
 
             if (obj is IDictionary dict)
@@ -257,7 +266,10 @@ namespace KitWright.Editor.MCP.Server
                     case '\n': sb.Append("\\n"); break;
                     case '\r': sb.Append("\\r"); break;
                     case '\t': sb.Append("\\t"); break;
-                    default: sb.Append(c); break;
+                    default:
+                        if (c < ' ') sb.Append("\\u").Append(((int)c).ToString("x4"));
+                        else sb.Append(c);
+                        break;
                 }
             }
             return sb.ToString();

--- a/Editor/MCP/Server/JsonCodec.cs
+++ b/Editor/MCP/Server/JsonCodec.cs
@@ -17,6 +17,17 @@ namespace KitWright.Editor.MCP.Server
     {
         public static string Serialize(object obj)
         {
+            return Serialize(obj, 0);
+        }
+
+        private static string Serialize(object obj, int depth)
+        {
+            // Serialize recurses through nested containers; without this a deep or cyclic graph
+            // overflows the stack, which is uncatchable and takes the editor down. Deserialize
+            // already caps at the same depth.
+            if (depth > MaxDepth)
+                throw new Exception("JSON nesting too deep");
+
             if (obj == null)
                 return "null";
 
@@ -35,17 +46,18 @@ namespace KitWright.Editor.MCP.Server
                     ? "null"
                     : Convert.ToString(obj, CultureInfo.InvariantCulture);
             }
-            if (obj is int || obj is long)
+            if (obj is int || obj is long || obj is uint || obj is ulong ||
+                obj is byte || obj is sbyte || obj is short || obj is ushort || obj is decimal)
                 return Convert.ToString(obj, CultureInfo.InvariantCulture);
 
             if (obj is IDictionary dict)
-                return SerializeDictionary(dict);
+                return SerializeDictionary(dict, depth);
 
             if (obj is IList list)
-                return SerializeList(list);
+                return SerializeList(list, depth);
 
             if (IsAnonymousType(obj.GetType()))
-                return SerializeAnonymous(obj);
+                return SerializeAnonymous(obj, depth);
 
             return "\"" + EscapeString(obj.ToString()) + "\"";
         }
@@ -58,7 +70,7 @@ namespace KitWright.Editor.MCP.Server
                    type.Name.IndexOf("AnonymousType", StringComparison.Ordinal) >= 0;
         }
 
-        private static string SerializeAnonymous(object obj)
+        private static string SerializeAnonymous(object obj, int depth)
         {
             var sb = new StringBuilder();
             sb.Append("{");
@@ -71,14 +83,14 @@ namespace KitWright.Editor.MCP.Server
                 sb.Append("\"");
                 sb.Append(EscapeString(property.Name));
                 sb.Append("\":");
-                sb.Append(Serialize(property.GetValue(obj)));
+                sb.Append(Serialize(property.GetValue(obj), depth + 1));
             }
 
             sb.Append("}");
             return sb.ToString();
         }
 
-        private static string SerializeDictionary(IDictionary dict)
+        private static string SerializeDictionary(IDictionary dict, int depth)
         {
             var sb = new StringBuilder();
             sb.Append("{");
@@ -91,14 +103,14 @@ namespace KitWright.Editor.MCP.Server
                 sb.Append("\"");
                 sb.Append(EscapeString(entry.Key.ToString()));
                 sb.Append("\":");
-                sb.Append(Serialize(entry.Value));
+                sb.Append(Serialize(entry.Value, depth + 1));
             }
 
             sb.Append("}");
             return sb.ToString();
         }
 
-        private static string SerializeList(IList list)
+        private static string SerializeList(IList list, int depth)
         {
             var sb = new StringBuilder();
             sb.Append("[");
@@ -108,7 +120,7 @@ namespace KitWright.Editor.MCP.Server
             {
                 if (!first) sb.Append(",");
                 first = false;
-                sb.Append(Serialize(item));
+                sb.Append(Serialize(item, depth + 1));
             }
 
             sb.Append("]");

--- a/Editor/Tools/Scripting/CompiledCodeGuard.cs
+++ b/Editor/Tools/Scripting/CompiledCodeGuard.cs
@@ -61,7 +61,11 @@ namespace KitWright.Editor.Tools.Scripting
             "System.Reflection.Assembly.LoadFrom",
             "System.Reflection.Assembly.LoadFile",
             "System.Linq.Expressions.Expression.Call",
-            "System.Reflection.Emit.ILGenerator.Emit"
+            "System.Reflection.Emit.ILGenerator.Emit",
+            // A raw function pointer + a marshalled delegate reaches the target through neither
+            // MethodBase.Invoke nor CreateDelegate; block both ends of that chain.
+            "System.RuntimeMethodHandle.GetFunctionPointer",
+            "System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer"
         };
 
         // A modal dialog or file picker runs its own message loop, which stops the editor from

--- a/Editor/Tools/Scripting/CompiledCodeGuard.cs
+++ b/Editor/Tools/Scripting/CompiledCodeGuard.cs
@@ -131,7 +131,8 @@ namespace KitWright.Editor.Tools.Scripting
             foreach (var module in assembly.GetModules())
             {
                 if (ScanTypeRefs(module, strict, ref reference, ref reason) ||
-                    ScanMemberRefs(module, strict, ref reference, ref reason))
+                    ScanMemberRefs(module, strict, ref reference, ref reason) ||
+                    ScanForPInvoke(module, ref reference, ref reason))
                     return true;
             }
 
@@ -201,6 +202,43 @@ namespace KitWright.Editor.Tools.Scripting
             }
 
             WarnScanTruncated(module, "MemberRef");
+            return false;
+        }
+
+        // A [DllImport] method calls native code directly: it never references a blocked managed
+        // type or member, so the ref-table scans above are blind to it. Its P/Invoke flag lives on
+        // the method definition instead, so this pass walks the defined methods for it.
+        private static bool ScanForPInvoke(Module module, ref string reference, ref string reason)
+        {
+            Type[] types;
+            try { types = module.GetTypes(); }
+            catch (ReflectionTypeLoadException ex) { types = ex.Types; }
+            catch { return false; }
+
+            const BindingFlags all = BindingFlags.Public | BindingFlags.NonPublic |
+                                     BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly;
+
+            foreach (var type in types)
+            {
+                if (type == null)
+                    continue;
+
+                MethodInfo[] methods;
+                try { methods = type.GetMethods(all); }
+                catch { continue; }
+
+                foreach (var method in methods)
+                {
+                    if ((method.Attributes & MethodAttributes.PinvokeImpl) == 0)
+                        continue;
+
+                    reference = $"{type.FullName}.{method.Name}";
+                    reason = $"The compiled snippet declares a native P/Invoke method '{reference}', " +
+                             "which calls unmanaged code directly and execute_code refuses to run.";
+                    return true;
+                }
+            }
+
             return false;
         }
 

--- a/Editor/Tools/Scripting/CompiledCodeGuard.cs
+++ b/Editor/Tools/Scripting/CompiledCodeGuard.cs
@@ -40,6 +40,30 @@ namespace KitWright.Editor.Tools.Scripting
             "UnityEditor.FileUtil.DeleteFileOrDirectory"
         };
 
+        // Reflection and expression trees launder a blocked call past every other check: the source
+        // never names Process/File.Delete (so the L1 regex misses) and the type is resolved from a
+        // runtime string (so no blocked TypeRef/MemberRef reaches the tables above). What the snippet
+        // cannot hide is the invocation primitive itself, which is a real MemberRef here. Blocking the
+        // primitives is the enforceable choke point.
+        // ponytail: best-effort, not a boundary. A determined caller can still reach IL through paths
+        // not listed here; the real boundary is safety_checks=false being unavailable, or out-of-process
+        // execution. Legitimate reflection under safety_checks=true must pass safety_checks=false.
+        private static readonly string[] BlockedReflectionMembers =
+        {
+            "System.Activator.CreateInstance",
+            "System.Reflection.MethodBase.Invoke",
+            "System.Reflection.MethodInfo.CreateDelegate",
+            "System.Delegate.CreateDelegate",
+            "System.Type.InvokeMember",
+            "System.Type.GetType",
+            "System.Reflection.Assembly.GetType",
+            "System.Reflection.Assembly.Load",
+            "System.Reflection.Assembly.LoadFrom",
+            "System.Reflection.Assembly.LoadFile",
+            "System.Linq.Expressions.Expression.Call",
+            "System.Reflection.Emit.ILGenerator.Emit"
+        };
+
         // A modal dialog or file picker runs its own message loop, which stops the editor from
         // pumping MCP requests: the snippet never returns and the caller hangs until a human clicks.
         private static readonly string[] ModalMembers =
@@ -163,7 +187,8 @@ namespace KitWright.Editor.Tools.Scripting
                     return true;
                 }
 
-                if (Matches(name, BlockedMembers) || (strict && Matches(name, StrictMembers)))
+                if (Matches(name, BlockedMembers) || Matches(name, BlockedReflectionMembers) ||
+                    (strict && Matches(name, StrictMembers)))
                 {
                     reference = name;
                     reason = $"The compiled snippet calls '{name}', which execute_code refuses to run.";

--- a/Editor/Tools/Scripting/CompiledCodeGuard.cs
+++ b/Editor/Tools/Scripting/CompiledCodeGuard.cs
@@ -23,7 +23,11 @@ namespace KitWright.Editor.Tools.Scripting
         private static readonly string[] BlockedTypes =
         {
             "System.Diagnostics.Process",
-            "System.IO.FileSystemWatcher"
+            "System.IO.FileSystemWatcher",
+            // Gadget-chain deserializers (ysoserial.net): live on Unity mono, never legit in a snippet.
+            "System.Runtime.Serialization.Formatters.Binary.BinaryFormatter",
+            "System.Runtime.Serialization.Formatters.Soap.SoapFormatter",
+            "System.Runtime.Serialization.NetDataContractSerializer"
         };
 
         private static readonly string[] BlockedMembers =
@@ -62,6 +66,8 @@ namespace KitWright.Editor.Tools.Scripting
             "System.Reflection.Assembly.LoadFile",
             "System.Linq.Expressions.Expression.Call",
             "System.Reflection.Emit.ILGenerator.Emit",
+            // Raw-IL injection without ILGenerator; mono-only, so unreachable on .NET Core today.
+            "System.Reflection.Emit.MethodBuilder.SetMethodBody",
             // A raw function pointer + a marshalled delegate reaches the target through neither
             // MethodBase.Invoke nor CreateDelegate; block both ends of that chain.
             "System.RuntimeMethodHandle.GetFunctionPointer",

--- a/Tests/Editor/CompiledCodeGuardTests.cs
+++ b/Tests/Editor/CompiledCodeGuardTests.cs
@@ -155,6 +155,22 @@ public class Native
     }
 }";
 
+        // A gadget-chain deserializer reaches RCE from a crafted blob without naming a blocked member;
+        // the type itself is the catch, since constructing one is never legitimate in a snippet.
+        private const string LegacyDeserializer = @"
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+
+public class Deser
+{
+    public static object Run()
+    {
+        var bf = new BinaryFormatter();
+        using var ms = new MemoryStream(new byte[] { 0, 1, 0, 0, 0 });
+        return bf.Deserialize(ms);
+    }
+}";
+
         [Test]
         public void SourcePolicy_MissesAnAliasedNamespace()
         {
@@ -281,6 +297,18 @@ public class Native
             Assert.IsTrue(CompiledCodeGuard.TryFindViolation(compilation.Assembly, true, out var reference, out var reason));
             Assert.AreEqual("Native.GetModuleHandle", reference);
             Assert.That(reason, Does.Contain("P/Invoke"));
+        }
+
+        [Test]
+        public void Guard_BlocksLegacyDeserializers()
+        {
+            Assert.IsFalse(ExecuteCodeSafetyPolicy.TryFindViolation(LegacyDeserializer, true, out _, out _));
+
+            var compilation = ScriptCompilerPipeline.Compile(LegacyDeserializer);
+            Assert.AreEqual(ScriptCompilationStatus.Success, compilation.Status, compilation.Message);
+
+            Assert.IsTrue(CompiledCodeGuard.TryFindViolation(compilation.Assembly, true, out var reference, out _));
+            Assert.AreEqual("System.Runtime.Serialization.Formatters.Binary.BinaryFormatter", reference);
         }
     }
 }

--- a/Tests/Editor/CompiledCodeGuardTests.cs
+++ b/Tests/Editor/CompiledCodeGuardTests.cs
@@ -120,6 +120,24 @@ public class RString
     }
 }";
 
+        // A raw function pointer plus a marshalled delegate reaches the target through neither
+        // MethodBase.Invoke nor CreateDelegate -- it survived the first reflection block.
+        private const string FunctionPointerMarshal = @"
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+public class FnPtr
+{
+    public static string Run()
+    {
+        var m = typeof(System.IO.File).GetMethods().First(x => x.Name == ""Delete"");
+        var ptr = m.MethodHandle.GetFunctionPointer();
+        var del = Marshal.GetDelegateForFunctionPointer(ptr, typeof(Action<string>));
+        return del == null ? ""n"" : ""y"";
+    }
+}";
+
         [Test]
         public void SourcePolicy_MissesAnAliasedNamespace()
         {
@@ -220,6 +238,19 @@ public class RString
 
             Assert.IsTrue(CompiledCodeGuard.TryFindViolation(compilation.Assembly, false, out var reference, out _));
             Assert.AreEqual("System.Reflection.Assembly.GetType", reference);
+        }
+
+        [Test]
+        public void Guard_BlocksTheFunctionPointerMarshalChain()
+        {
+            Assert.IsFalse(ExecuteCodeSafetyPolicy.TryFindViolation(FunctionPointerMarshal, true, out _, out _));
+
+            var compilation = ScriptCompilerPipeline.Compile(FunctionPointerMarshal);
+            Assert.AreEqual(ScriptCompilationStatus.Success, compilation.Status, compilation.Message);
+
+            Assert.IsTrue(CompiledCodeGuard.TryFindViolation(compilation.Assembly, true, out var reference, out _));
+            Assert.That(reference, Does.Contain("FunctionPointer"),
+                "Either the raw pointer extraction or the marshalled delegate must be refused.");
         }
     }
 }

--- a/Tests/Editor/CompiledCodeGuardTests.cs
+++ b/Tests/Editor/CompiledCodeGuardTests.cs
@@ -138,6 +138,23 @@ public class FnPtr
     }
 }";
 
+        // [DllImport] calls native code directly and references no blocked managed type or member,
+        // so the ref-table scans are blind to it; the P/Invoke flag on the method is the signal.
+        private const string PInvokeNative = @"
+using System;
+using System.Runtime.InteropServices;
+
+public class Native
+{
+    [DllImport(""kernel32.dll"", CharSet = CharSet.Unicode)]
+    static extern IntPtr GetModuleHandle(string name);
+
+    public static object Run()
+    {
+        return GetModuleHandle(""kernel32.dll"").ToString();
+    }
+}";
+
         [Test]
         public void SourcePolicy_MissesAnAliasedNamespace()
         {
@@ -251,6 +268,19 @@ public class FnPtr
             Assert.IsTrue(CompiledCodeGuard.TryFindViolation(compilation.Assembly, true, out var reference, out _));
             Assert.That(reference, Does.Contain("FunctionPointer"),
                 "Either the raw pointer extraction or the marshalled delegate must be refused.");
+        }
+
+        [Test]
+        public void Guard_BlocksNativePInvokeDeclarations()
+        {
+            Assert.IsFalse(ExecuteCodeSafetyPolicy.TryFindViolation(PInvokeNative, true, out _, out _));
+
+            var compilation = ScriptCompilerPipeline.Compile(PInvokeNative);
+            Assert.AreEqual(ScriptCompilationStatus.Success, compilation.Status, compilation.Message);
+
+            Assert.IsTrue(CompiledCodeGuard.TryFindViolation(compilation.Assembly, true, out var reference, out var reason));
+            Assert.AreEqual("Native.GetModuleHandle", reference);
+            Assert.That(reason, Does.Contain("P/Invoke"));
         }
     }
 }

--- a/Tests/Editor/CompiledCodeGuardTests.cs
+++ b/Tests/Editor/CompiledCodeGuardTests.cs
@@ -83,6 +83,43 @@ public class Benign
     }
 }";
 
+        // GetMethods() (plural) slips past the source rule's \.GetMethod\s*\( and .Invoke with a var
+        // slips past MethodInfo..Invoke, so the source policy misses this. The compiled snippet still
+        // binds to MethodBase.Invoke, which is where it is caught.
+        private const string ReflectedInvokeDelete = @"
+using System;
+using System.Linq;
+
+public class RInvoke
+{
+    public static string Run()
+    {
+        var m = typeof(System.IO.File).GetMethods().First(x => x.Name == ""Delete"");
+        m.Invoke(null, new object[] { ""probe.txt"" });
+        return ""done"";
+    }
+}";
+
+        // The type name is built at runtime and resolved through an Assembly instance, so neither the
+        // literal appears in source nor a Process TypeRef in the metadata. Assembly.GetType is the bind.
+        private const string RuntimeStringType = @"
+using System;
+using System.Linq;
+
+public class RString
+{
+    public static string Run()
+    {
+        string n = string.Concat(""System.Diagnostics.Proc"", ""ess"");
+        foreach (var a in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            var t = a.GetType(n);
+            if (t != null) return t.FullName;
+        }
+        return null;
+    }
+}";
+
         [Test]
         public void SourcePolicy_MissesAnAliasedNamespace()
         {
@@ -155,6 +192,34 @@ public class Benign
             Assert.AreEqual(ScriptCompilationStatus.Success, compilation.Status, compilation.Message);
 
             Assert.IsFalse(CompiledCodeGuard.TryFindViolation(compilation.Assembly, true, out _, out _));
+        }
+
+        // Reflection that actually invokes launders a blocked call past both the source rule and the
+        // metadata scan of the target member; the invocation primitive is the enforceable choke point.
+        [Test]
+        public void Guard_BlocksReflectionInvocation()
+        {
+            Assert.IsFalse(ExecuteCodeSafetyPolicy.TryFindViolation(ReflectedInvokeDelete, true, out _, out _));
+
+            var compilation = ScriptCompilerPipeline.Compile(ReflectedInvokeDelete);
+            Assert.AreEqual(ScriptCompilationStatus.Success, compilation.Status, compilation.Message);
+
+            Assert.IsTrue(CompiledCodeGuard.TryFindViolation(compilation.Assembly, true, out var reference, out _));
+            Assert.AreEqual("System.Reflection.MethodBase.Invoke", reference);
+        }
+
+        // A type name built at runtime resolves through Assembly.GetType, leaving no dangerous TypeRef;
+        // blocking the resolver closes the runtime-string path both strict settings share.
+        [Test]
+        public void Guard_BlocksRuntimeStringTypeResolution()
+        {
+            Assert.IsFalse(ExecuteCodeSafetyPolicy.TryFindViolation(RuntimeStringType, true, out _, out _));
+
+            var compilation = ScriptCompilerPipeline.Compile(RuntimeStringType);
+            Assert.AreEqual(ScriptCompilationStatus.Success, compilation.Status, compilation.Message);
+
+            Assert.IsTrue(CompiledCodeGuard.TryFindViolation(compilation.Assembly, false, out var reference, out _));
+            Assert.AreEqual("System.Reflection.Assembly.GetType", reference);
         }
     }
 }

--- a/Tests/Editor/HttpMCPTransportLifecycleTests.cs
+++ b/Tests/Editor/HttpMCPTransportLifecycleTests.cs
@@ -546,6 +546,21 @@ namespace KitWright.Editor
             Assert.IsFalse(HttpMCPTransport.IsValidOrigin("http://attacker.local"));
         }
 
+        // DNS-rebinding defense independent of Origin: a rebound name resolves to 127.0.0.1 but the
+        // browser still sends its Host, so a non-loopback Host must be refused.
+        [Test]
+        public void HostValidation_AcceptsAbsentAndLoopback_RejectsReboundName()
+        {
+            Assert.IsTrue(HttpMCPTransport.IsValidHost(null), "Absent Host (HTTP/1.0) must be allowed.");
+            Assert.IsTrue(HttpMCPTransport.IsValidHost(""), "Empty Host must be allowed.");
+            Assert.IsTrue(HttpMCPTransport.IsValidHost("127.0.0.1:8766"));
+            Assert.IsTrue(HttpMCPTransport.IsValidHost("localhost:8766"));
+            Assert.IsTrue(HttpMCPTransport.IsValidHost("[::1]:8766"));
+            Assert.IsTrue(HttpMCPTransport.IsValidHost("127.0.0.1"));
+            Assert.IsFalse(HttpMCPTransport.IsValidHost("evil.com:8766"));
+            Assert.IsFalse(HttpMCPTransport.IsValidHost("attacker.local:8766"));
+        }
+
         [UnityTest]
         public IEnumerator PostInitialize_ReturnsMcpSessionIdHeader()
         {

--- a/Tests/Editor/JsonCodecTests.cs
+++ b/Tests/Editor/JsonCodecTests.cs
@@ -54,5 +54,24 @@ namespace KitWright.Editor.Tests
             Assert.AreEqual("{\"k\":\"v\"}",
                 JsonCodec.Serialize(new Dictionary<string, object> { ["k"] = "v" }));
         }
+
+        [Test]
+        public void Serialize_EscapesControlCharsSoAReflectedNullByteStaysValidJson()
+        {
+            Assert.AreEqual("\"a\\u0000b\"", JsonCodec.Serialize("a\0b"));
+            Assert.AreEqual("\"\\u001f\"", JsonCodec.Serialize("\u001f"));
+            Assert.AreEqual("\"\\n\\t\"", JsonCodec.Serialize("\n\t"),
+                "Named escapes must not regress to \\u form.");
+        }
+
+        [Test]
+        public void Serialize_DropsNonFiniteFloatsToNullSoTheResponseStaysValidJson()
+        {
+            Assert.AreEqual("null", JsonCodec.Serialize(double.PositiveInfinity));
+            Assert.AreEqual("null", JsonCodec.Serialize(double.NegativeInfinity));
+            Assert.AreEqual("null", JsonCodec.Serialize(double.NaN));
+            Assert.AreEqual("null", JsonCodec.Serialize(float.PositiveInfinity));
+            Assert.AreEqual("1.5", JsonCodec.Serialize(1.5), "Finite floats must still serialize.");
+        }
     }
 }

--- a/Tests/Editor/JsonCodecTests.cs
+++ b/Tests/Editor/JsonCodecTests.cs
@@ -73,5 +73,31 @@ namespace KitWright.Editor.Tests
             Assert.AreEqual("null", JsonCodec.Serialize(float.PositiveInfinity));
             Assert.AreEqual("1.5", JsonCodec.Serialize(1.5), "Finite floats must still serialize.");
         }
+
+        [Test]
+        public void Serialize_EmitsBareNumbersForEveryIntegerType()
+        {
+            // Only int/long were caught before; the rest fell through to the string fallback and
+            // reached the client as a quoted string ("42") instead of a number.
+            Assert.AreEqual("42", JsonCodec.Serialize((uint)42));
+            Assert.AreEqual("42", JsonCodec.Serialize((ulong)42));
+            Assert.AreEqual("5", JsonCodec.Serialize((byte)5));
+            Assert.AreEqual("-5", JsonCodec.Serialize((sbyte)-5));
+            Assert.AreEqual("3", JsonCodec.Serialize((short)3));
+            Assert.AreEqual("7", JsonCodec.Serialize((ushort)7));
+            Assert.AreEqual("1.5", JsonCodec.Serialize(1.5m));
+        }
+
+        [Test]
+        public void Serialize_ThrowsInsteadOfOverflowingTheStackOnDeepNesting()
+        {
+            object nested = "leaf";
+            for (int i = 0; i < 200; i++)
+                nested = new List<object> { nested };
+
+            Assert.That(() => JsonCodec.Serialize(nested),
+                Throws.Exception.With.Message.Contains("too deep"),
+                "A deep or cyclic graph must fail catchably, not StackOverflow the editor.");
+        }
     }
 }

--- a/Tests/Editor/JsonCodecTests.cs
+++ b/Tests/Editor/JsonCodecTests.cs
@@ -99,5 +99,27 @@ namespace KitWright.Editor.Tests
                 Throws.Exception.With.Message.Contains("too deep"),
                 "A deep or cyclic graph must fail catchably, not StackOverflow the editor.");
         }
+
+        [Test]
+        public void Deserialize_KeepsBraceAndBracketCharactersInsideNestedStringValues()
+        {
+            // FindValueEnd counted braces/brackets without skipping string bodies, so a nested value
+            // like {"opts":{"note":"a}b"}} was truncated at the brace inside the string -- the codec
+            // could not even round-trip its own output.
+            var obj = (Dictionary<string, object>)JsonCodec.Deserialize("{\"opts\":{\"note\":\"a}b\"}}");
+            var inner = (Dictionary<string, object>)obj["opts"];
+            Assert.AreEqual("a}b", inner["note"]);
+
+            var arr = (Dictionary<string, object>)JsonCodec.Deserialize("{\"arr\":[\"x]y\"]}");
+            var list = (List<object>)arr["arr"];
+            Assert.AreEqual("x]y", list[0]);
+
+            var original = new Dictionary<string, object>
+            {
+                ["opts"] = new Dictionary<string, object> { ["note"] = "close } here" }
+            };
+            var roundTripped = (Dictionary<string, object>)JsonCodec.Deserialize(JsonCodec.Serialize(original));
+            Assert.AreEqual("close } here", ((Dictionary<string, object>)roundTripped["opts"])["note"]);
+        }
     }
 }

--- a/Tests/Editor/MCPBrokerSpawnArgumentsTests.cs
+++ b/Tests/Editor/MCPBrokerSpawnArgumentsTests.cs
@@ -1,0 +1,34 @@
+// Copyright (C) KitWright. Licensed under MIT.
+
+using KitWright.Editor.MCP.Server;
+using NUnit.Framework;
+
+namespace KitWright.Editor.Tests
+{
+    // Regression for the "spaces in the path crash the client" class seen in competing Unity MCP
+    // servers: the broker executable lives under a path like C:\Program Files\..., so its spawn
+    // argument must stay a single quoted token or the process launcher splits it at the space.
+    public sealed class MCPBrokerSpawnArgumentsTests
+    {
+        [Test]
+        public void BuildSpawnArguments_QuotesAnExecutablePathContainingSpaces()
+        {
+            var args = MCPBrokerProcessManager.BuildSpawnArguments(
+                @"C:\Program Files\KitWright\broker.exe", 8766, "tok", "pin123");
+
+            Assert.That(args, Does.StartWith("\"C:\\Program Files\\KitWright\\broker.exe\""),
+                "The executable path must be one quoted token so a space does not split it.");
+        }
+
+        [Test]
+        public void BuildSpawnArguments_CarriesPortTokenPinAndProtocol()
+        {
+            var args = MCPBrokerProcessManager.BuildSpawnArguments("broker.exe", 8766, "tok", "pin123");
+
+            Assert.That(args, Does.Contain("--port 8766"));
+            Assert.That(args, Does.Contain("--token tok"));
+            Assert.That(args, Does.Contain("--pin pin123"));
+            Assert.That(args, Does.Contain("--protocol "));
+        }
+    }
+}

--- a/Tests/Editor/SecurityGuaranteeGuardTests.cs
+++ b/Tests/Editor/SecurityGuaranteeGuardTests.cs
@@ -1,0 +1,131 @@
+// Copyright (C) KitWright. Licensed under MIT.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using KitWright.Editor.Tools.Scripting;
+using NUnit.Framework;
+
+namespace KitWright.Editor.Tests
+{
+    /// <summary>
+    /// Source scan (no server, no license needed): SECURITY.md publishes guarantees a report can
+    /// hold us to. PathSafetyTests already covers project containment; these cover the other two,
+    /// which had nothing failing when they broke.
+    ///
+    /// Strings, chars and comments are masked before matching, so prose naming a forbidden API does
+    /// not fail the scan and a real call cannot hide inside a literal.
+    /// </summary>
+    public sealed class SecurityGuaranteeGuardTests
+    {
+        // "Loopback only. The HTTP transport binds IPAddress.Loopback and the keepalive broker
+        // listens on 127.0.0.1. There is no LAN bind option, so anything reachable off-host is a bug."
+        private static readonly string[] OffHostBinds =
+        {
+            @"IPAddress\.Any",
+            @"IPAddress\.IPv6Any",
+            @"IPAddress\.Broadcast",
+            // A parsed address is one config value away from a LAN bind.
+            @"IPAddress\.Parse\s*\(",
+        };
+
+        // The token lives in exactly three files: the broker validates it, the process manager
+        // spawns with it, the client transport sends it as a header.
+        private static readonly string[] TokenBearingSources =
+        {
+            "Editor/MCP/Server/Broker/keepalive-broker.cs.txt",
+            "Editor/MCP/Server/Broker/MCPBrokerProcessManager.cs",
+            "Editor/MCP/Server/Broker/MCPBrokerClientTransport.cs",
+        };
+
+        [Test]
+        public void ShippedListenerBinds_AreLoopbackOnly()
+        {
+            var violations = new List<string>();
+
+            foreach (var source in ShippedSources())
+            {
+                var lines = source.Masked.Split('\n');
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    foreach (var pattern in OffHostBinds)
+                        if (Regex.IsMatch(lines[i], pattern))
+                            violations.Add($"{source.Name}:{i + 1} binds off-host -- {lines[i].Trim()}");
+
+                    // A listener built from a variable hides which address it was handed, so the
+                    // address has to be written at the construction site. The optional qualifier
+                    // matters: MCPServerService spells it System.Net.Sockets.TcpListener.
+                    if (Regex.IsMatch(lines[i], @"new\s+(?:[\w.]+\.)?TcpListener\s*\(") &&
+                        !lines[i].Contains("IPAddress.Loopback"))
+                        violations.Add(
+                            $"{source.Name}:{i + 1} constructs a TcpListener with no IPAddress.Loopback " +
+                            $"on the same line -- {lines[i].Trim()}");
+                }
+            }
+
+            Assert.IsEmpty(violations,
+                "SECURITY.md promises loopback only, so anything reachable off-host is a bug:\n"
+                + string.Join("\n", violations));
+        }
+
+        [Test]
+        public void ShippedCode_IntroducesNoHttpListener()
+        {
+            // http.sys binds by URL prefix rather than by IPAddress, so a migration would route
+            // around ShippedListenerBinds_AreLoopbackOnly and leave it green while the guarantee
+            // went unchecked. Adding one means teaching that test to read Prefixes first.
+            foreach (var source in ShippedSources())
+                Assert.That(source.Masked, Does.Not.Match(@"new\s+(?:[\w.]+\.)?HttpListener\s*\("),
+                    source.Name + " introduces HttpListener, whose bind address "
+                    + nameof(ShippedListenerBinds_AreLoopbackOnly) + " cannot see.");
+        }
+
+        [Test]
+        public void NoLogCall_CarriesTheBrokerToken()
+        {
+            var violations = new List<string>();
+
+            foreach (var relative in TokenBearingSources)
+            {
+                var path = Path.Combine(OptionalModuleGuardTests.PackageRoot(), relative);
+                Assert.IsTrue(File.Exists(path),
+                    "A token-bearing source moved, so this scan no longer covers it: " + path);
+
+                var lines = CSharpMemberEditor.Mask(File.ReadAllText(path)).Split('\n');
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    if (!Regex.IsMatch(lines[i], @"\b(Debug\.Log\w*|Log)\s*\("))
+                        continue;
+                    // Arguments is the spawn command line, which carries --token. The lookbehind
+                    // keeps the CancellationToken idiom out: cts.Token is qualified, every real
+                    // token identifier here (Token, _token, token, spawnToken) is not.
+                    if (!Regex.IsMatch(lines[i],
+                            @"(?<![\w.])_?[Tt]oken\b|BuildSpawnArguments|\bArguments\b"))
+                        continue;
+
+                    violations.Add($"{Path.GetFileName(path)}:{i + 1} -- {lines[i].Trim()}");
+                }
+            }
+
+            Assert.IsEmpty(violations,
+                "SECURITY.md promises broker tokens never reach a log. Log the pid and the port "
+                + "instead:\n" + string.Join("\n", violations));
+        }
+
+        // Editor/ plus the broker text: that is the shipped server. Tests/ stands up listeners of
+        // its own on purpose - HttpMCPTransportLifecycleTests fakes a server to hold a port.
+        private static IEnumerable<(string Name, string Masked)> ShippedSources()
+        {
+            var root = OptionalModuleGuardTests.PackageRoot();
+
+            foreach (var file in Directory.GetFiles(
+                         Path.Combine(root, "Editor"), "*.cs", SearchOption.AllDirectories))
+                yield return (Path.GetFileName(file), CSharpMemberEditor.Mask(File.ReadAllText(file)));
+
+            var broker = Path.Combine(root, "Editor/MCP/Server/Broker/keepalive-broker.cs.txt");
+            Assert.IsTrue(File.Exists(broker),
+                "The broker source moved, so the listener scan no longer covers it: " + broker);
+            yield return (Path.GetFileName(broker), CSharpMemberEditor.Mask(File.ReadAllText(broker)));
+        }
+    }
+}

--- a/Tests/Editor/SecurityGuaranteeGuardTests.cs.meta
+++ b/Tests/Editor/SecurityGuaranteeGuardTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7c3d9e18b04a4f2ab6157de90c4a3f61


### PR DESCRIPTION
## What changed

- Describe the change briefly
- Explain the user impact or motivation

## Checklist

- [ ] I tested the package in a clean Unity 2022.3+ project
- [ ] I verified `Window > KitWright > MCP Window` opens and the server starts correctly
- [ ] If I added, renamed, or removed a tool, I ran `python scripts/generate_tools_doc.py`
- [ ] If I changed setup, update, or config flows, I verified the affected flow end-to-end
- [ ] I updated docs for any user-facing behavior changes
- [ ] I did not commit local junk such as `.idea/` or `.DS_Store`
- [ ] I updated `CHANGELOG.md` when the change affects users
