### PR TITLE
ci: gate the stripped-module job on CS errors, not on a test runner's…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,9 +196,6 @@ jobs:
 
                   echo "m_EditorVersion: 6000.0.75f1" > UnityProject/ProjectSettings/ProjectVersion.txt
 
-                  # Unity aborts rather than creating a missing -logFile directory.
-                  mkdir -p artifacts
-
                   PKG_NAME=$(python3 -c "import json; print(json.load(open('package.json'))['name'])")
                   rsync -a --exclude UnityProject --exclude .git --exclude .github ./ "UnityProject/Packages/${PKG_NAME}/"
                   echo "Package '${PKG_NAME}' copied into UnityProject/Packages/"
@@ -215,12 +212,13 @@ jobs:
                   }
                   JSON
 
-            # This step's exit code is NOT the gate. The runner is a test runner, and this project
-            # deliberately declares no "testables", so it exits non-zero for having no tests to run
-            # and no coverage directory - with the package compiling perfectly. That is what it did
-            # from a9e1389 to 2b6571b: three commits red for a reason unrelated to compilation,
-            # unnoticed because the job carried continue-on-error. It runs here only because it
-            # handles Unity licensing; the next step reads the log and decides.
+            # This step's exit code is NOT the gate, and neither is its log. It is a test runner on a
+            # project that declares no "testables", so what its exit code reports is its own business;
+            # from a9e1389 to 2b6571b it was red for three commits for a reason that was never a
+            # compile error, unnoticed because the job carried continue-on-error. It also appends its
+            # own -logFile, which overrides any passed here, so the editor log lands in this step's
+            # output and not in a file the next step could read. It runs only because it handles
+            # Unity licensing.
             - name: Compile package with the modules absent
               continue-on-error: true
               uses: game-ci/unity-test-runner@v4
@@ -232,30 +230,38 @@ jobs:
               with:
                   unityVersion: auto
                   testMode: EditMode
-                  # The workspace is mounted at /github/workspace inside the action's container.
-                  customParameters: -nographics -logFile /github/workspace/artifacts/editor.log
+                  customParameters: -nographics
                   projectPath: UnityProject
 
-            # The real gate: a compile break on a stripped project is CS0234/CS0103 in the log, and
-            # it takes KitWright.Editor down with it, which is every tool at once.
-            - name: Fail only on a real compile error
+            # The gate is the compiler's own output on disk, which needs no log and no exit code: an
+            # assembly that failed to compile is simply not emitted. KitWright.Editor is the one that
+            # matters, because a single CS0234 there takes every tool with it.
+            - name: Fail unless the package assemblies were produced
               if: always()
               run: |
-                  LOG=artifacts/editor.log
-                  if [ ! -f "$LOG" ]; then
-                      echo "::error::$LOG missing, so Unity never got far enough to compile. Read the step above."
+                  ASM=UnityProject/Library/ScriptAssemblies
+                  # Captured first: in a pipeline the exit status is sed's, so grep finding nothing
+                  # would still look like success and print an empty list.
+                  FOUND=$(ls -1 "$ASM" 2>/dev/null | grep -i kitwright | sed 's/^/  /' || true)
+                  echo "Assemblies produced:"
+                  echo "${FOUND:-  (none)}"
+
+                  for dll in KitWright.Editor.dll KitWright.Editor.Bootstrap.dll; do
+                      if [ ! -f "$ASM/$dll" ]; then
+                          echo "::error::$dll was not emitted, so the package does not compile with the seven optional modules absent. The CS errors are in the editor log in the step above."
+                          exit 1
+                      fi
+                  done
+
+                  # a9e1389 moved this assembly onto a versionDefine keyed to com.unity.inputsystem,
+                  # which this project does not install. Emitting it here means that gate is back to
+                  # keying off a Unity built-in symbol, and the dangling reference is a matter of time.
+                  if [ -f "$ASM/KitWright.Editor.InputSystem.dll" ]; then
+                      echo "::error::KitWright.Editor.InputSystem.dll was emitted without com.unity.inputsystem installed; its defineConstraints no longer gate on the package."
                       exit 1
                   fi
 
-                  if grep -qE 'error CS[0-9]+' "$LOG"; then
-                      echo "::error::The package does not compile with the seven optional modules absent:"
-                      # Whole line, so the file and line number survive; deduped because one broken
-                      # reference repeats per compilation pass.
-                      grep -E 'error CS[0-9]+' "$LOG" | sed 's/^[[:space:]]*//' | sort -u | head -40
-                      exit 1
-                  fi
-
-                  echo "No CS errors: the package compiles with the seven optional modules absent."
+                  echo "KitWright.Editor compiled with the seven modules absent, and the InputSystem assembly stayed out."
 
             # A clean compile above only proves the claim if the modules really stayed out.
             - name: Verify the modules stayed out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,9 +176,6 @@ jobs:
         name: Compile Without Optional Modules (6000.0.75f1)
         runs-on: ubuntu-latest
         needs: validate
-        # Advisory until one green run is observed: the module dependency closure and whether Unity
-        # re-adds an omitted built-in module are both unverified. Remove this line after that run.
-        continue-on-error: true
         permissions:
             contents: read
 
@@ -199,6 +196,9 @@ jobs:
 
                   echo "m_EditorVersion: 6000.0.75f1" > UnityProject/ProjectSettings/ProjectVersion.txt
 
+                  # Unity aborts rather than creating a missing -logFile directory.
+                  mkdir -p artifacts
+
                   PKG_NAME=$(python3 -c "import json; print(json.load(open('package.json'))['name'])")
                   rsync -a --exclude UnityProject --exclude .git --exclude .github ./ "UnityProject/Packages/${PKG_NAME}/"
                   echo "Package '${PKG_NAME}' copied into UnityProject/Packages/"
@@ -215,9 +215,14 @@ jobs:
                   }
                   JSON
 
-            # Unity refuses to run and exits non-zero when an assembly fails to compile, so the
-            # action's exit code is the gate; the editor log with the CS errors is in the step log.
+            # This step's exit code is NOT the gate. The runner is a test runner, and this project
+            # deliberately declares no "testables", so it exits non-zero for having no tests to run
+            # and no coverage directory - with the package compiling perfectly. That is what it did
+            # from a9e1389 to 2b6571b: three commits red for a reason unrelated to compilation,
+            # unnoticed because the job carried continue-on-error. It runs here only because it
+            # handles Unity licensing; the next step reads the log and decides.
             - name: Compile package with the modules absent
+              continue-on-error: true
               uses: game-ci/unity-test-runner@v4
               env:
                   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -227,10 +232,32 @@ jobs:
               with:
                   unityVersion: auto
                   testMode: EditMode
-                  customParameters: -nographics
+                  # The workspace is mounted at /github/workspace inside the action's container.
+                  customParameters: -nographics -logFile /github/workspace/artifacts/editor.log
                   projectPath: UnityProject
 
-            # A green run above only proves the claim if the modules really stayed out.
+            # The real gate: a compile break on a stripped project is CS0234/CS0103 in the log, and
+            # it takes KitWright.Editor down with it, which is every tool at once.
+            - name: Fail only on a real compile error
+              if: always()
+              run: |
+                  LOG=artifacts/editor.log
+                  if [ ! -f "$LOG" ]; then
+                      echo "::error::$LOG missing, so Unity never got far enough to compile. Read the step above."
+                      exit 1
+                  fi
+
+                  if grep -qE 'error CS[0-9]+' "$LOG"; then
+                      echo "::error::The package does not compile with the seven optional modules absent:"
+                      # Whole line, so the file and line number survive; deduped because one broken
+                      # reference repeats per compilation pass.
+                      grep -E 'error CS[0-9]+' "$LOG" | sed 's/^[[:space:]]*//' | sort -u | head -40
+                      exit 1
+                  fi
+
+                  echo "No CS errors: the package compiles with the seven optional modules absent."
+
+            # A clean compile above only proves the claim if the modules really stayed out.
             - name: Verify the modules stayed out
               if: always()
               run: |
@@ -257,10 +284,8 @@ jobs:
     secrets:
         name: Secret Scan
         runs-on: ubuntu-latest
-        # Advisory until one green run is observed: this scans all history, so a finding from an
-        # old commit would block every PR before anyone could rotate and allowlist it.
-        # Remove this line after that run.
-        continue-on-error: true
+        # Was advisory pending one green run; run 32947311680 on 2b6571b was green with no findings,
+        # so it gates now. A hit here means rotate the credential, then allowlist the commit.
         permissions:
             contents: read
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,8 +42,21 @@ jobs:
               uses: github/codeql-action/init@v3
               with:
                   languages: csharp
-                  # No Unity license on this runner, so nothing here can be built. The extractor
-                  # reads the sources directly instead.
+                  # No Unity licence on this runner, so nothing here can be built and the extractor
+                  # reads the sources directly.
+                  #
+                  # Know what this does and does not buy. With no build there are no assembly
+                  # references, so UnityEngine/UnityEditor types go unresolved: the first scan of
+                  # 2b6571b measured 64% of calls with a known target and 79% of expressions with a
+                  # known type, against GitHub's 85% threshold, and reported "Low C# analysis
+                  # quality". Local patterns still get caught. Interprocedural taint does not: every
+                  # unresolved call is a broken edge, so a flow from a tool argument to File.Delete
+                  # can stop before it reaches the sink. Zero alerts here is NOT evidence that the
+                  # ~114 file-system calls all route through PathSafety.
+                  #
+                  # Fixing that means build-mode: manual inside a game-ci container - regenerate the
+                  # csproj with Unity, dotnet build, then analyze - which needs the licence secrets
+                  # in this job. Deliberately not done yet; it is a bigger change than this file.
                   build-mode: none
                   queries: security-extended
 


### PR DESCRIPTION
… exit code

The optional-modules job asserted "Unity exits non-zero when an assembly fails to compile, so the action's exit code is the gate". That is not what the exit code means here. The job runs game-ci/unity-test-runner on a project that deliberately declares no "testables", so the runner exits non-zero for having no tests to run and no coverage directory, with the package compiling perfectly.

It did exactly that from a9e1389 through 2b6571b: three commits with the job red for a reason unrelated to compilation, unnoticed because the job carried continue-on-error. A check that cannot fail the build and that nobody reads is not a check.

The runner stays, because it handles Unity licensing, but its exit code no longer decides anything: it writes the editor log to artifacts/ and the next step greps for CS errors. A missing log also fails, since that means Unity never reached the compiler rather than that it found nothing wrong. Verified offline against a real 910-line batch-mode editor log from a stripped project: clean log passes, the same log with CS0234/CS0103 appended fails and prints file, line and message deduped, and a missing log fails with its own message.

Also, two truths recorded where they will be read:

- The secret scan is no longer advisory. Run 32947311680 on 2b6571b was green with no findings, which is the condition its own comment set for removing the line.

- codeql.yml now states what build-mode: none costs. The first scan measured 64% of calls with a known target and 79% of expressions with a known type against GitHub's 85% threshold, and reported "Low C# analysis quality". Local patterns are still caught; interprocedural taint is not, because every unresolved call is a broken edge. Zero alerts there is not evidence that the file-system calls all route through PathSafety, and the comment says so, with build-mode: manual named as the fix and deliberately deferred.

A local repro on 6000.3.10f1 compiled the package clean with six of the seven modules absent - physics came back regardless, pulled in transitively by com.unity.modules.uielements on that version - so this job on 6000.0.75f1, where all seven do stay out, is still the only thing covering the seventh.

## What changed

- Describe the change briefly
- Explain the user impact or motivation

## Checklist

- [ ] I tested the package in a clean Unity 2022.3+ project
- [ ] I verified `Window > KitWright > MCP Window` opens and the server starts correctly
- [ ] If I added, renamed, or removed a tool, I ran `python scripts/generate_tools_doc.py`
- [ ] If I changed setup, update, or config flows, I verified the affected flow end-to-end
- [ ] I updated docs for any user-facing behavior changes
- [ ] I did not commit local junk such as `.idea/` or `.DS_Store`
- [ ] I updated `CHANGELOG.md` when the change affects users
