### PR TITLE
ci(codeql): give the buildless extractor Unity's assemblies to resolv…

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,6 +38,52 @@ jobs:
                   cp "$src" codeql-staging/keepalive-broker.cs
                   echo "Staged $(wc -l < codeql-staging/keepalive-broker.cs) lines of broker source."
 
+            # The buildless extractor resolves what it can find on disk, and what it cannot find here
+            # is every Unity type: 64% of calls had a known target on the first scan. Unity's managed
+            # assemblies are the missing half. Copying them out of the game-ci image needs no licence
+            # and never starts the editor - the container is created and removed without being run.
+            #
+            # Self-diagnosing on purpose: the tag and the install path are the two things that can
+            # drift, so a miss prints what the image actually holds instead of failing blind.
+            - name: Stage Unity reference assemblies
+              id: refs
+              run: |
+                  IMAGE=""
+                  for tag in \
+                      unityci/editor:ubuntu-6000.0.75f1-base-3 \
+                      unityci/editor:ubuntu-6000.0.75f1-base-2 \
+                      unityci/editor:6000.0.75f1-base-3; do
+                      if docker pull -q "$tag" >/dev/null 2>&1; then IMAGE="$tag"; break; fi
+                  done
+                  if [ -z "$IMAGE" ]; then
+                      echo "::error::None of the candidate unityci/editor tags could be pulled."
+                      exit 1
+                  fi
+                  echo "image: $IMAGE"
+
+                  CID=$(docker create "$IMAGE")
+                  trap 'docker rm -f "$CID" >/dev/null 2>&1 || true' EXIT
+
+                  mkdir -p unity-refs
+                  FOUND=""
+                  for dir in \
+                      /opt/unity/Editor/Data/Managed \
+                      /opt/Unity/Editor/Data/Managed \
+                      /usr/share/unity3d/Editor/Data/Managed; do
+                      if docker cp "$CID:$dir/." unity-refs/ 2>/dev/null; then FOUND="$dir"; break; fi
+                  done
+
+                  if [ -z "$FOUND" ]; then
+                      echo "::error::No Editor/Data/Managed in $IMAGE. Directories under /opt:"
+                      docker cp "$CID:/opt/." /tmp/probe 2>/dev/null || true
+                      find /tmp/probe -maxdepth 4 -type d 2>/dev/null | head -40
+                      exit 1
+                  fi
+
+                  COUNT=$(find unity-refs -name '*.dll' | wc -l)
+                  echo "Copied $COUNT reference assemblies from $FOUND ($(du -sh unity-refs | cut -f1))"
+                  test "$COUNT" -ge 50 || { echo "::error::Only $COUNT dlls; expected ~159."; exit 1; }
+
             - name: Initialize CodeQL
               uses: github/codeql-action/init@v3
               with:
@@ -45,18 +91,20 @@ jobs:
                   # No Unity licence on this runner, so nothing here can be built and the extractor
                   # reads the sources directly.
                   #
-                  # Know what this does and does not buy. With no build there are no assembly
-                  # references, so UnityEngine/UnityEditor types go unresolved: the first scan of
-                  # 2b6571b measured 64% of calls with a known target and 79% of expressions with a
-                  # known type, against GitHub's 85% threshold, and reported "Low C# analysis
+                  # Know what this does and does not buy. The first scan of 2b6571b, with nothing but
+                  # the sources, measured 64% of calls with a known target and 79% of expressions
+                  # with a known type against GitHub's 85% threshold, and reported "Low C# analysis
                   # quality". Local patterns still get caught. Interprocedural taint does not: every
                   # unresolved call is a broken edge, so a flow from a tool argument to File.Delete
-                  # can stop before it reaches the sink. Zero alerts here is NOT evidence that the
-                  # ~114 file-system calls all route through PathSafety.
+                  # can stop before it reaches the sink. Zero alerts under those numbers is NOT
+                  # evidence that the file-system calls all route through PathSafety.
                   #
-                  # Fixing that means build-mode: manual inside a game-ci container - regenerate the
-                  # csproj with Unity, dotnet build, then analyze - which needs the licence secrets
-                  # in this job. Deliberately not done yet; it is a bigger change than this file.
+                  # The step above now stages Unity's managed assemblies, which is the cheap half of
+                  # the fix: references without a build. Check the reported percentages after a run.
+                  # If they still sit under 85%, the remaining gap is the tracer - CodeQL reaches its
+                  # numbers by watching the compiler run, and no arrangement of loose dlls replaces
+                  # that. The next rung is build-mode: manual with the extraction and the compile in
+                  # the same container, which is a bigger change than this file.
                   build-mode: none
                   queries: security-extended
 


### PR DESCRIPTION
…e against

Round one of two on the C# analysis quality, cheapest rung first.

The first scan reported "Low C# analysis quality": 64% of calls with a known target and 79% of expressions with a known type, against a threshold of 85%. Nothing in the checkout defines UnityEngine or UnityEditor, so every call into the engine is an unresolved edge, and interprocedural taint stops at the first one. That is why zero alerts said nothing about whether the file-system calls route through PathSafety.

References are the half of that gap obtainable without a build. This copies Editor/Data/Managed out of the game-ci editor image - 19 assemblies plus the 140 UnityEngine/UnityEditor modules beside them, ~159 dlls, layout confirmed against a local 6000.3.10f1 install. It needs no licence and never starts the editor: the container is created, copied out of, and removed without being run.

The step is deliberately self-diagnosing, because the image tag and the install path are exactly what drifts and neither could be checked locally - no docker on this machine. It tries three tags and three paths, prints which combination worked, asserts at least 50 dlls landed, and on a miss dumps the directories the image actually has rather than failing blind. One run answers it either way.

What this cannot buy is the tracer. CodeQL reaches its numbers by watching the compiler run, and loose dlls are not a substitute. If the percentages stay under 85% after this, the next rung is build-mode: manual with extraction and compile in one container, and the comment in the workflow says so.

Not verified beyond YAML and bash -n: the tag, the path and whether the buildless extractor picks up loose assemblies at all are what this run is for.

## What changed

- Describe the change briefly
- Explain the user impact or motivation

## Checklist

- [ ] I tested the package in a clean Unity 2022.3+ project
- [ ] I verified `Window > KitWright > MCP Window` opens and the server starts correctly
- [ ] If I added, renamed, or removed a tool, I ran `python scripts/generate_tools_doc.py`
- [ ] If I changed setup, update, or config flows, I verified the affected flow end-to-end
- [ ] I updated docs for any user-facing behavior changes
- [ ] I did not commit local junk such as `.idea/` or `.DS_Store`
- [ ] I updated `CHANGELOG.md` when the change affects users
