### PR TITLE
refactor(ui): one JSON parser, one switch

### DIFF
--- a/Editor/UI/ClientConfigPanel.cs
+++ b/Editor/UI/ClientConfigPanel.cs
@@ -7,6 +7,8 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using KitWright.Editor.Services;
 using KitWright.Editor.Settings;
 using KitWright.Editor.Tools.Helpers;
@@ -347,15 +349,10 @@ namespace KitWright.Editor.MCP.Server
             if (target.IsToml)
                 return CreateTomlSection(target);
 
+            // Built by the same merge the Configure button writes, so what the user copies is byte
+            // for byte what lands in the file.
             var rootKey = string.IsNullOrEmpty(target.RootKey) ? "mcpServers" : target.RootKey;
-            var root = new Dictionary<string, object>
-            {
-                [rootKey] = new Dictionary<string, object> { [ServerEntryName] = CreateHttpEntry(target) }
-            };
-            if (!string.IsNullOrEmpty(target.SchemaUrl))
-                root["$schema"] = target.SchemaUrl;
-
-            return Newtonsoft.Json.JsonConvert.SerializeObject(root, Newtonsoft.Json.Formatting.Indented);
+            return MergeJsonConfig(null, rootKey, ServerEntryName, CreateHttpEntry(target), target.SchemaUrl, target.ConfigPath);
         }
 
         public void RefreshStatus()
@@ -405,23 +402,6 @@ namespace KitWright.Editor.MCP.Server
                 : $"{problemPath} posts to a URL that is not {liveUrl}. A URL on a stale port, or one " +
                   "written before project pinning, reaches whichever editor now owns that port -- so " +
                   "tool calls can land in a sibling project.";
-        }
-
-        // JsonCodec's reader is lenient by design -- it stops at the first thing it does not
-        // understand and returns what it collected, so a truncated file comes back as a partial
-        // dictionary rather than null. Rewriting that drops every server past the truncation, which
-        // is the loss the callers are guarding against, so validate with the strict reader.
-        private static bool IsWellFormedJson(string json)
-        {
-            try
-            {
-                Newtonsoft.Json.Linq.JToken.Parse(json);
-                return true;
-            }
-            catch (Newtonsoft.Json.JsonException)
-            {
-                return false;
-            }
         }
 
         private static string ReadConfigText(string path)
@@ -759,11 +739,18 @@ namespace KitWright.Editor.MCP.Server
         // JSON only: the sole client that shadows is Antigravity, and Codex is the only TOML target.
         private static bool RemoveOurEntries(string path, string text, MCPConfigTarget target)
         {
-            if (!IsWellFormedJson(text) || !(JsonCodec.Deserialize(text) is Dictionary<string, object> root))
+            JObject root;
+            try
+            {
+                root = JObject.Parse(text);
+            }
+            catch (JsonException)
+            {
                 return false;
+            }
 
             var rootKey = string.IsNullOrEmpty(target.RootKey) ? "mcpServers" : target.RootKey;
-            if (!(root.TryGetValue(rootKey, out var serversObj) && serversObj is Dictionary<string, object> servers))
+            if (!(root[rootKey] is JObject servers))
                 return true;
 
             var removed = servers.Remove(ServerEntryName);
@@ -773,7 +760,7 @@ namespace KitWright.Editor.MCP.Server
                 removed |= servers.Remove(legacy);
 
             if (removed)
-                AtomicFile.WriteAllText(path, JsonCodec.Serialize(root));
+                AtomicFile.WriteAllText(path, root.ToString(Formatting.Indented));
 
             return true;
         }
@@ -814,46 +801,44 @@ namespace KitWright.Editor.MCP.Server
             string schemaUrl,
             string configPath)
         {
-            Dictionary<string, object> root;
-            var parsed = JsonCodec.Deserialize(existingJson) as Dictionary<string, object>;
+            var root = ParseConfigRoot(existingJson, configPath);
 
-            // A file we cannot parse that still has content holds servers we cannot see. Rewriting
-            // it would drop every one of them, so stop and let the user fix it. A blank file carries
-            // nothing, so it falls through and gets rebuilt.
-            if (!string.IsNullOrWhiteSpace(existingJson) && (parsed == null || !IsWellFormedJson(existingJson)))
+            if (!(root[rootKey] is JObject servers))
+            {
+                servers = new JObject();
+                root[rootKey] = servers;
+            }
+
+            servers.Remove(PinnedServerEntryName());
+            servers.Remove(ProductServerEntryName());
+            foreach (var legacy in LegacyServerEntryNames())
+                servers.Remove(legacy);
+            servers[serverName] = JToken.FromObject(entry);
+
+            if (!string.IsNullOrEmpty(schemaUrl) && root["$schema"] == null)
+                root["$schema"] = schemaUrl;
+
+            return root.ToString(Formatting.Indented);
+        }
+
+        // A file we cannot parse that still has content holds servers we cannot see. Rewriting it
+        // would drop every one of them, so stop and let the user fix it. A blank file carries
+        // nothing, so it starts a fresh root.
+        private static JObject ParseConfigRoot(string existingJson, string configPath)
+        {
+            if (string.IsNullOrWhiteSpace(existingJson))
+                return new JObject();
+
+            try
+            {
+                return JObject.Parse(existingJson);
+            }
+            catch (JsonException)
+            {
                 throw new IOException(
                     $"{configPath} is not valid JSON. Refusing to overwrite it so other MCP servers " +
                     "in the file are not lost. Fix or delete the file, then configure again.");
-
-            if (parsed != null && parsed.ContainsKey(rootKey))
-            {
-                root = parsed;
-                var servers = root[rootKey] as Dictionary<string, object>;
-                if (servers != null)
-                {
-                    servers.Remove(PinnedServerEntryName());
-                    servers.Remove(ProductServerEntryName());
-                    foreach (var legacy in LegacyServerEntryNames())
-                        servers.Remove(legacy);
-                    servers[serverName] = entry;
-                }
-                else
-                    root[rootKey] = new Dictionary<string, object> { [serverName] = entry };
             }
-            else
-            {
-                root = parsed ?? new Dictionary<string, object>();
-                root[rootKey] = new Dictionary<string, object> { [serverName] = entry };
-            }
-
-            if (!string.IsNullOrEmpty(schemaUrl) && !root.ContainsKey("$schema"))
-                root["$schema"] = schemaUrl;
-
-            var json = JsonCodec.Serialize(root);
-            if (string.IsNullOrWhiteSpace(json))
-                throw new IOException($"Serializing the MCP configuration produced no content; {configPath} was left untouched.");
-
-            return json;
         }
 
         private void ConfigureTomlTarget(MCPConfigTarget target)

--- a/Editor/UI/MCPSwitchToggle.cs
+++ b/Editor/UI/MCPSwitchToggle.cs
@@ -13,8 +13,47 @@ namespace KitWright.Editor.MCP.Server
     /// </summary>
     internal sealed class MCPSwitchToggle : VisualElement
     {
-        private static readonly Color OnTrack = MCPPalette.AccentGreen;
-        private static readonly Color OffTrack = new Color(0.62f, 0.26f, 0.26f);
+        // Shared with the Tool Exposure list, which builds the same switch but drives its state
+        // from outside. Keeping the look in one place is what stops the two drifting apart.
+        internal static readonly Color OnTrack = MCPPalette.AccentGreen;
+        internal static readonly Color OffTrack = new Color(0.62f, 0.26f, 0.26f);
+        internal static readonly List<TimeValue> Slide = new List<TimeValue> { new TimeValue(0.1f, TimeUnit.Second) };
+        internal static readonly List<TimeValue> Instant = new List<TimeValue> { new TimeValue(0, TimeUnit.Second) };
+
+        internal const int KnobLeftOn = 18;
+        internal const int KnobLeftOff = 2;
+
+        private static readonly List<StylePropertyName> TrackTransition = new List<StylePropertyName> { "background-color" };
+        private static readonly List<StylePropertyName> KnobTransition = new List<StylePropertyName> { "left" };
+        private static readonly List<EasingFunction> KnobEasing = new List<EasingFunction> { new EasingFunction(EasingMode.EaseOutCubic) };
+
+        /// <summary>Track with its knob as the first child. Colour, knob side and duration are the caller's.</summary>
+        internal static VisualElement CreateTrack()
+        {
+            var track = new VisualElement();
+            track.style.width = 34;
+            track.style.height = 18;
+            track.style.flexShrink = 0;
+            track.style.backgroundColor = OffTrack;
+            track.Rounded(9);
+            track.style.transitionProperty = TrackTransition;
+            track.style.transitionDuration = Instant;
+
+            var knob = new VisualElement();
+            knob.style.position = Position.Absolute;
+            knob.style.width = 14;
+            knob.style.height = 14;
+            knob.style.top = 2;
+            knob.style.left = KnobLeftOff;
+            knob.style.backgroundColor = Color.white;
+            knob.Rounded(7);
+            knob.style.transitionProperty = KnobTransition;
+            knob.style.transitionDuration = Instant;
+            knob.style.transitionTimingFunction = KnobEasing;
+            track.Add(knob);
+
+            return track;
+        }
 
         private readonly Label _label;
         private readonly VisualElement _track;
@@ -33,28 +72,13 @@ namespace KitWright.Editor.MCP.Server
             _label.style.color = new Color(0.85f, 0.85f, 0.85f);
             Add(_label);
 
-            _track = new VisualElement();
-            _track.style.width = 34;
-            _track.style.height = 18;
-            _track.style.flexShrink = 0;
-            _track.style.backgroundColor = OffTrack;
-            _track.Rounded(9);
-            _track.style.transitionProperty = new List<StylePropertyName> { "background-color" };
-            _track.style.transitionDuration = new List<TimeValue> { new TimeValue(0.1f, TimeUnit.Second) };
-            Add(_track);
+            _track = CreateTrack();
+            _knob = _track[0];
 
-            _knob = new VisualElement();
-            _knob.style.position = Position.Absolute;
-            _knob.style.width = 14;
-            _knob.style.height = 14;
-            _knob.style.top = 2;
-            _knob.style.left = 2;
-            _knob.style.backgroundColor = Color.white;
-            _knob.Rounded(7);
-            _knob.style.transitionProperty = new List<StylePropertyName> { "left" };
-            _knob.style.transitionDuration = new List<TimeValue> { new TimeValue(0.1f, TimeUnit.Second) };
-            _knob.style.transitionTimingFunction = new List<EasingFunction> { new EasingFunction(EasingMode.EaseOutCubic) };
-            _track.Add(_knob);
+            // Every change here is a click, so it always slides.
+            _track.style.transitionDuration = Slide;
+            _knob.style.transitionDuration = Slide;
+            Add(_track);
 
             RegisterCallback<ClickEvent>(_ =>
             {
@@ -82,7 +106,7 @@ namespace KitWright.Editor.MCP.Server
         private void UpdateVisual()
         {
             _track.style.backgroundColor = _value ? OnTrack : OffTrack;
-            _knob.style.left = _value ? 18 : 2;
+            _knob.style.left = _value ? KnobLeftOn : KnobLeftOff;
         }
     }
 }

--- a/Editor/UI/ToolExposureEditorPanel.cs
+++ b/Editor/UI/ToolExposureEditorPanel.cs
@@ -36,16 +36,6 @@ namespace KitWright.Editor.MCP.Server
 
         private static readonly Color SegmentActive = new Color(0.24f, 0.42f, 0.58f);
         private static readonly Color SegmentInactive = MCPPalette.Surface;
-        private static readonly Color SwitchOnTrack = MCPPalette.AccentGreen;
-        private static readonly Color SwitchOffTrack = new Color(0.62f, 0.26f, 0.26f);
-
-        // BindRow runs for every visible row on every scroll, so these are built once rather than
-        // allocated per bind.
-        private static readonly List<StylePropertyName> SwitchTrackProperty = new List<StylePropertyName> { "background-color" };
-        private static readonly List<StylePropertyName> SwitchKnobProperty = new List<StylePropertyName> { "left" };
-        private static readonly List<TimeValue> SwitchSlide = new List<TimeValue> { new TimeValue(0.1f, TimeUnit.Second) };
-        private static readonly List<TimeValue> SwitchInstant = new List<TimeValue> { new TimeValue(0, TimeUnit.Second) };
-        private static readonly List<EasingFunction> SwitchEasing = new List<EasingFunction> { new EasingFunction(EasingMode.EaseOutCubic) };
 
         // Clicks slide, scrolling snaps -- both land in BindRow, and only a recent click can have
         // opened this window. Wide enough to cover a rebind that waits for the next layout pass.
@@ -747,10 +737,10 @@ namespace KitWright.Editor.MCP.Server
             view.ToolDescription.text = hasDescription ? description : string.Empty;
             view.ToolRow.tooltip = hasDescription ? description : entry.Tool;
             var slide = EditorApplication.timeSinceStartup < _slideUntil;
-            view.Switch.style.transitionDuration = slide ? SwitchSlide : SwitchInstant;
-            view.Knob.style.transitionDuration = slide ? SwitchSlide : SwitchInstant;
-            view.Switch.style.backgroundColor = isOn ? SwitchOnTrack : SwitchOffTrack;
-            view.Knob.style.left = isOn ? 18 : 2;
+            view.Switch.style.transitionDuration = slide ? MCPSwitchToggle.Slide : MCPSwitchToggle.Instant;
+            view.Knob.style.transitionDuration = slide ? MCPSwitchToggle.Slide : MCPSwitchToggle.Instant;
+            view.Switch.style.backgroundColor = isOn ? MCPSwitchToggle.OnTrack : MCPSwitchToggle.OffTrack;
+            view.Knob.style.left = isOn ? MCPSwitchToggle.KnobLeftOn : MCPSwitchToggle.KnobLeftOff;
         }
 
         private static string HighlightMatch(string text, string filter)
@@ -769,31 +759,7 @@ namespace KitWright.Editor.MCP.Server
         }
 
         // State (track colour, knob side) is applied in BindRow, which also sets the duration.
-        private static VisualElement CreateSwitch()
-        {
-            var track = new VisualElement();
-            track.style.width = 34;
-            track.style.height = 18;
-            track.style.flexShrink = 0;
-            track.Rounded(9);
-            track.style.justifyContent = Justify.Center;
-            track.style.transitionProperty = SwitchTrackProperty;
-            track.style.transitionDuration = SwitchInstant;
-
-            var knob = new VisualElement();
-            knob.style.position = Position.Absolute;
-            knob.style.width = 14;
-            knob.style.height = 14;
-            knob.style.top = 2;
-            knob.style.backgroundColor = Color.white;
-            knob.Rounded(7);
-            knob.style.transitionProperty = SwitchKnobProperty;
-            knob.style.transitionDuration = SwitchInstant;
-            knob.style.transitionTimingFunction = SwitchEasing;
-            track.Add(knob);
-
-            return track;
-        }
+        private static VisualElement CreateSwitch() => MCPSwitchToggle.CreateTrack();
 
         private Button CreateCategoryButton(string text, Action action)
         {


### PR DESCRIPTION
Two cleanups the previous change made visible rather than introduced.

JsonCodec parsed the config and Newtonsoft then re-parsed it just to tell
whether the first parse could be trusted. Newtonsoft is already a hard
dependency here, and JObject.Parse throws on malformed input by itself, so
the merge now uses it end to end: the strict-validation helper, the
null-check clause and the empty-serialisation guard all go.

That also settles a mismatch nobody had noticed: the Manual Configuration
snippet was serialised by Newtonsoft while the file was written by JsonCodec,
so what the user copied and what Configure wrote were formatted differently.
The snippet is now built by the same merge that does the writing.

The two on/off switches had drifted into being the same widget once the Tool
Exposure one started animating -- same geometry, colours, transition and
easing, declared twice. The look lives on MCPSwitchToggle now; the list asks
it for a bare track and keeps driving the state itself.

Written config files change formatting (Newtonsoft indentation). JSON
semantics are unchanged.