### PR TITLE
feat(tools): keep tools whose package is missing off the switches

### DIFF
--- a/Editor/MCP/Server/MCPToolExportPolicy.cs
+++ b/Editor/MCP/Server/MCPToolExportPolicy.cs
@@ -128,6 +128,10 @@ namespace KitWright.Editor.MCP.Server
             if (string.IsNullOrWhiteSpace(toolName))
                 return false;
 
+            // Applies to a hand-picked profile too: a saved list can outlive the package it needs.
+            if (ToolPackageGate.IsUnavailable(toolName))
+                return false;
+
             if (profileConfigured)
                 return ContainsTool(profileTools, toolName);
 
@@ -165,6 +169,7 @@ namespace KitWright.Editor.MCP.Server
         {
             return (allToolNames ?? Enumerable.Empty<string>())
                 .Where(name => !string.IsNullOrWhiteSpace(name)
+                               && !ToolPackageGate.IsUnavailable(name)
                                && (IsInDefaultSet(name, profile) || ToolRegistry.IsCustomTool(name)));
         }
 

--- a/Editor/Tools/Attributes/ToolAttributes.cs
+++ b/Editor/Tools/Attributes/ToolAttributes.cs
@@ -17,6 +17,22 @@ namespace KitWright.Editor.Tools
         }
     }
 
+    /// The package id a tool needs at runtime, on the provider class or on a single method.
+    /// Use it where the code still compiles without the package and answers with a "not installed"
+    /// error instead: the Tool Exposure editor greys those tools out so nobody switches on a tool
+    /// that cannot run. Tools that simply vanish with their package (an asmdef defineConstraint, or
+    /// a whole class inside #if) need nothing here.
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public class RequiresPackageAttribute : Attribute
+    {
+        public string PackageId { get; }
+
+        public RequiresPackageAttribute(string packageId)
+        {
+            PackageId = packageId;
+        }
+    }
+
     [AttributeUsage(AttributeTargets.Parameter)]
     public class ToolParamAttribute : Attribute
     {

--- a/Editor/Tools/Builtins/AddressableFunctions.cs
+++ b/Editor/Tools/Builtins/AddressableFunctions.cs
@@ -12,6 +12,7 @@ using UnityEditor.AddressableAssets.Settings;
 namespace KitWright.Editor.Tools.Builtins
 {
     [ToolProvider("Addressable")]
+    [RequiresPackage("com.unity.addressables")]
     internal static class AddressableFunctions
     {
         private const string NoPackageHint =

--- a/Editor/Tools/Builtins/MemorySnapshotFunctions.cs
+++ b/Editor/Tools/Builtins/MemorySnapshotFunctions.cs
@@ -167,6 +167,7 @@ namespace KitWright.Editor.Tools.Builtins
                      "(see memory_list_full_snapshots). Requires the com.unity.memoryprofiler package. " +
                      "Combine with capture_editor_window('Memory Profiler') to inspect the loaded analysis visually.")]
         [ReadOnlyTool]
+        [RequiresPackage("com.unity.memoryprofiler")]
         public static string MemoryOpenSnapshotInProfiler(
             [ToolParam("Absolute .snap path, or a file name inside the snapshot folder (with or without the .snap extension).")] string snapshot)
         {
@@ -197,6 +198,7 @@ namespace KitWright.Editor.Tools.Builtins
                      "the memory' half of the workflow started by memory_take_full_snapshot. Loads headlessly via the " +
                      "Memory Profiler package's crawler (no window opened); requires the com.unity.memoryprofiler package.")]
         [ReadOnlyTool]
+        [RequiresPackage("com.unity.memoryprofiler")]
         public static string MemoryQueryTopObjects(
             [ToolParam("Absolute .snap path, or a file name inside the snapshot folder (with or without the .snap extension).")] string snapshot,
             [ToolParam("Only include objects whose native type name contains this text (case-insensitive), e.g. 'Texture2D'.", Required = false)] string type_filter = null,
@@ -255,6 +257,7 @@ namespace KitWright.Editor.Tools.Builtins
                      "the com.unity.memoryprofiler package. Only native objects can be looked up directly; the returned " +
                      "reference lists may include managed objects and GC handles as informational entries.")]
         [ReadOnlyTool]
+        [RequiresPackage("com.unity.memoryprofiler")]
         public static string MemoryQueryReferences(
             [ToolParam("Absolute .snap path, or a file name inside the snapshot folder (with or without the .snap extension).")] string snapshot,
             [ToolParam("Native object name (exact match preferred, falls back to a case-insensitive substring match) or the native_object_index from memory_query_top_objects.")] string target,

--- a/Editor/Tools/Builtins/TimelineFunctions.cs
+++ b/Editor/Tools/Builtins/TimelineFunctions.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 namespace KitWright.Editor.Tools.Builtins
 {
     [ToolProvider("Timeline")]
+    [RequiresPackage("com.unity.modules.director")]
     internal static class TimelineFunctions
     {
         // Resolved by FullName over the target's components so this file compiles WITHOUT an

--- a/Editor/Tools/Builtins/VolumeFunctions.cs
+++ b/Editor/Tools/Builtins/VolumeFunctions.cs
@@ -15,6 +15,7 @@ using UnityEngine.Rendering;
 namespace KitWright.Editor.Tools.Builtins
 {
     [ToolProvider("Volume")]
+    [RequiresPackage("com.unity.render-pipelines.universal")]
     internal static class VolumeFunctions
     {
         private const string UrpRequiredHint =

--- a/Editor/Tools/ToolPackageGate.cs
+++ b/Editor/Tools/ToolPackageGate.cs
@@ -1,0 +1,68 @@
+// Copyright (C) KitWright. Licensed under MIT.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEditor;
+using PackageInfo = UnityEditor.PackageManager.PackageInfo;
+
+namespace KitWright.Editor.Tools
+{
+    /// Which registered tools cannot actually run here because an optional package is missing.
+    ///
+    /// A provider marked with <see cref="RequiresPackageAttribute"/> keeps compiling without its
+    /// package -- its methods answer with a "not installed" error so a direct caller gets a hint
+    /// rather than "unknown tool". Those tools must still stay out of the exported surface and out
+    /// of the Tool Exposure switches, or a profile happily turns on tools that can only fail.
+    internal static class ToolPackageGate
+    {
+        // Built on the main thread; tools/list can read it from the server's thread, which only
+        // ever sees a finished dictionary.
+        private static Dictionary<string, string> _missing = new Dictionary<string, string>();
+
+        public static bool IsUnavailable(string toolName)
+        {
+            return toolName != null && _missing.ContainsKey(toolName);
+        }
+
+        public static string MissingPackageFor(string toolName)
+        {
+            return toolName != null && _missing.TryGetValue(toolName, out var package) ? package : null;
+        }
+
+        /// Runs on load and after every domain reload; call it directly once a package is installed
+        /// so the gate reopens without waiting for one.
+        [InitializeOnLoadMethod]
+        public static void Invalidate()
+        {
+            var installed = new HashSet<string>(
+                PackageInfo.GetAllRegisteredPackages().Select(package => package.name),
+                StringComparer.OrdinalIgnoreCase);
+
+            _missing = Compute(ToolRegistry.MethodCache.Keys, installed);
+        }
+
+        internal static Dictionary<string, string> Compute(
+            IEnumerable<string> toolNames, ICollection<string> installedPackages)
+        {
+            var missing = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var toolName in toolNames)
+            {
+                if (!ToolRegistry.MethodCache.TryGetValue(toolName, out var method))
+                    continue;
+
+                // A method's own requirement wins: a provider can be mostly package-free and still
+                // have a handful of calls that go through the package.
+                var required = method.GetCustomAttribute<RequiresPackageAttribute>()?.PackageId
+                    ?? method.DeclaringType?.GetCustomAttribute<RequiresPackageAttribute>()?.PackageId;
+
+                if (!string.IsNullOrEmpty(required) && !installedPackages.Contains(required))
+                    missing[toolName] = required;
+            }
+
+            return missing;
+        }
+    }
+}

--- a/Editor/Tools/ToolPackageGate.cs.meta
+++ b/Editor/Tools/ToolPackageGate.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 826af1beb39db7341bc0c106f8cdabfc

--- a/Editor/UI/IntegrationsPanel.cs
+++ b/Editor/UI/IntegrationsPanel.cs
@@ -176,25 +176,18 @@ namespace KitWright.Editor.MCP.Server
 
                 button.text = "Installing...";
                 button.SetEnabled(false);
-                var req = UnityEditor.PackageManager.Client.Add(integration.PackageId);
-                EditorApplication.CallbackFunction poll = null;
-                poll = () =>
+                PackageInstaller.Install(integration.PackageId, (ok, error) =>
                 {
-                    if (!req.IsCompleted)
-                        return;
-                    EditorApplication.update -= poll;
-                    if (req.Status == UnityEditor.PackageManager.StatusCode.Success)
+                    if (ok)
                     {
                         button.text = "Installed";
+                        return;
                     }
-                    else
-                    {
-                        button.text = "Install";
-                        button.SetEnabled(true);
-                        EditorUtility.DisplayDialog("Package Install Error", req.Error?.message ?? "Unknown error", "OK");
-                    }
-                };
-                EditorApplication.update += poll;
+
+                    button.text = "Install";
+                    button.SetEnabled(true);
+                    EditorUtility.DisplayDialog("Package Install Error", error ?? "Unknown error", "OK");
+                });
             };
 
             return button;

--- a/Editor/UI/PackageInstaller.cs
+++ b/Editor/UI/PackageInstaller.cs
@@ -1,0 +1,29 @@
+// Copyright (C) KitWright. Licensed under MIT.
+
+using System;
+using UnityEditor;
+using UnityEditor.PackageManager;
+
+namespace KitWright.Editor.MCP.Server
+{
+    /// Adds a package and reports the outcome once the request settles. Shared by the Integrations
+    /// cards and the Tool Exposure switches, which both offer to install what a tool is missing.
+    internal static class PackageInstaller
+    {
+        public static void Install(string packageId, Action<bool, string> onCompleted)
+        {
+            var request = Client.Add(packageId);
+
+            EditorApplication.CallbackFunction poll = null;
+            poll = () =>
+            {
+                if (!request.IsCompleted)
+                    return;
+
+                EditorApplication.update -= poll;
+                onCompleted(request.Status == StatusCode.Success, request.Error?.message);
+            };
+            EditorApplication.update += poll;
+        }
+    }
+}

--- a/Editor/UI/PackageInstaller.cs.meta
+++ b/Editor/UI/PackageInstaller.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 00afe31f823d4b843a2b4c13e846d480

--- a/Editor/UI/ToolExposureEditorPanel.cs
+++ b/Editor/UI/ToolExposureEditorPanel.cs
@@ -45,6 +45,9 @@ namespace KitWright.Editor.MCP.Server
         private static readonly Color RowOffBg = new Color(0.165f, 0.165f, 0.17f);
         private static readonly Color RowOnText = new Color(0.92f, 0.95f, 0.90f);
         private static readonly Color RowOffText = new Color(0.72f, 0.72f, 0.72f);
+        private static readonly Color RowLockedText = new Color(0.48f, 0.48f, 0.50f);
+        private static readonly Color RowDescriptionText = new Color(0.55f, 0.55f, 0.58f);
+        private static readonly Color SwitchLockedTrack = new Color(0.28f, 0.28f, 0.30f);
 
         public ToolExposureEditorPanel(SettingsController settingsController, MCPServerService mcpServer)
         {
@@ -129,7 +132,7 @@ namespace KitWright.Editor.MCP.Server
             clearButton.style.marginLeft = 6;
             buttonRow.Add(clearButton);
 
-            var defaultButton = CreateActionButton("Restore Default", UseDefaultTools, 106, new Color(0.34f, 0.34f, 0.34f));
+            var defaultButton = CreateActionButton("Reset", UseDefaultTools, 64, new Color(0.34f, 0.34f, 0.34f));
             defaultButton.style.marginLeft = 6;
             buttonRow.Add(defaultButton);
 
@@ -397,7 +400,11 @@ namespace KitWright.Editor.MCP.Server
                 button.style.marginBottom = 0;
                 button.style.marginLeft = 0;
                 button.style.marginRight = 0;
-                button.Rounded(0);
+                // Overflow.Hidden on the group clips to a rectangle, not to its radius, so the end
+                // segments carry the rounding themselves.
+                var outer = ProfileChoices.Count - 1;
+                button.style.borderTopLeftRadius = button.style.borderBottomLeftRadius = i == 0 ? 4 : 0;
+                button.style.borderTopRightRadius = button.style.borderBottomRightRadius = i == outer ? 4 : 0;
                 button.style.borderLeftWidth = i == 0 ? 0 : 1;
                 button.style.borderRightWidth = 0;
                 button.style.borderTopWidth = 0;
@@ -470,6 +477,35 @@ namespace KitWright.Editor.MCP.Server
 
             foreach (var toolName in _allToolNames)
                 _toolCategories[toolName] = GetToolCategory(toolName);
+        }
+
+        // Switching on a tool whose package is missing is a reasonable way to say "I want this
+        // tool", so answer with the install rather than a dead switch.
+        private void OfferPackageInstall(string toolName)
+        {
+            var packageId = ToolPackageGate.MissingPackageFor(toolName);
+            if (packageId == null)
+                return;
+
+            if (!EditorUtility.DisplayDialog(
+                    $"Install {packageId}?",
+                    $"{toolName} needs it. Unity reloads after installing.",
+                    "Install",
+                    "Cancel"))
+                return;
+
+            PackageInstaller.Install(packageId, (ok, error) =>
+            {
+                ToolPackageGate.Invalidate();
+
+                if (!ok)
+                    EditorUtility.DisplayDialog("Package Install Error", error ?? "Unknown error", "OK");
+
+                // The install triggers a domain reload that rebuilds this window; refresh anyway so
+                // a no-reload outcome (already installed, or a failure) still redraws correctly.
+                if (_root != null)
+                    BuildUI();
+            });
         }
 
         private void LoadEditingTools()
@@ -590,8 +626,17 @@ namespace KitWright.Editor.MCP.Server
 
         private void ToggleTool(string toolName)
         {
-            if (!_editingTools.Remove(toolName))
+            var removed = _editingTools.Remove(toolName);
+            if (!removed)
+            {
+                // Still removable, so a profile saved before the package went missing can be cleaned up.
+                if (ToolPackageGate.IsUnavailable(toolName))
+                {
+                    OfferPackageInstall(toolName);
+                    return;
+                }
                 _editingTools.Add(toolName);
+            }
 
             _slideUntil = EditorApplication.timeSinceStartup + SlideWindow;
             RefreshRows();
@@ -729,17 +774,22 @@ namespace KitWright.Editor.MCP.Server
             }
 
             var isOn = _editingTools.Contains(entry.Tool);
+            var missingPackage = ToolPackageGate.MissingPackageFor(entry.Tool);
+            var locked = missingPackage != null;
             view.ToolName.enableRichText = hasFilter;
             view.ToolName.text = HighlightMatch(entry.Tool, _searchFilter);
-            view.ToolName.style.color = isOn ? RowOnText : RowOffText;
+            view.ToolName.style.color = locked ? RowLockedText : isOn ? RowOnText : RowOffText;
             view.ToolRow.style.backgroundColor = RowBg(entry, hover: false);
             var hasDescription = _toolDescriptions.TryGetValue(entry.Tool, out var description) && !string.IsNullOrWhiteSpace(description);
             view.ToolDescription.text = hasDescription ? description : string.Empty;
-            view.ToolRow.tooltip = hasDescription ? description : entry.Tool;
+            view.ToolDescription.style.color = locked ? RowLockedText : RowDescriptionText;
+            view.ToolRow.tooltip = locked
+                ? $"{entry.Tool} needs '{missingPackage}'. Click to install it."
+                : hasDescription ? description : entry.Tool;
             var slide = EditorApplication.timeSinceStartup < _slideUntil;
             view.Switch.style.transitionDuration = slide ? MCPSwitchToggle.Slide : MCPSwitchToggle.Instant;
             view.Knob.style.transitionDuration = slide ? MCPSwitchToggle.Slide : MCPSwitchToggle.Instant;
-            view.Switch.style.backgroundColor = isOn ? MCPSwitchToggle.OnTrack : MCPSwitchToggle.OffTrack;
+            view.Switch.style.backgroundColor = isOn ? MCPSwitchToggle.OnTrack : locked ? SwitchLockedTrack : MCPSwitchToggle.OffTrack;
             view.Knob.style.left = isOn ? MCPSwitchToggle.KnobLeftOn : MCPSwitchToggle.KnobLeftOff;
         }
 
@@ -791,10 +841,10 @@ namespace KitWright.Editor.MCP.Server
 
             foreach (var toolName in categoryTools)
             {
-                if (enabled)
-                    _editingTools.Add(toolName);
-                else
+                if (!enabled)
                     _editingTools.Remove(toolName);
+                else if (!ToolPackageGate.IsUnavailable(toolName))
+                    _editingTools.Add(toolName);
             }
 
             RefreshRows();
@@ -803,7 +853,8 @@ namespace KitWright.Editor.MCP.Server
         private void SetAllToolToggles(bool enabled)
         {
             if (enabled)
-                _editingTools = new HashSet<string>(_allToolNames, StringComparer.OrdinalIgnoreCase);
+                _editingTools = new HashSet<string>(
+                    _allToolNames.Where(tool => !ToolPackageGate.IsUnavailable(tool)), StringComparer.OrdinalIgnoreCase);
             else
                 _editingTools.Clear();
 

--- a/Tests/Editor/ToolExposurePackageGateTests.cs
+++ b/Tests/Editor/ToolExposurePackageGateTests.cs
@@ -1,0 +1,99 @@
+// Copyright (C) KitWright. Licensed under MIT.
+
+using System.Collections.Generic;
+using System.Linq;
+using KitWright.Editor.MCP.Server;
+using KitWright.Editor.Tools;
+using NUnit.Framework;
+
+namespace KitWright.Editor.Tests
+{
+    /// A provider that keeps compiling without its package registers tools that can only answer
+    /// "<package> required". Neither the exported surface nor the Tool Exposure switches may offer
+    /// those, or a profile turns on tools that can only fail.
+    public sealed class ToolExposurePackageGateTests
+    {
+        private static readonly string[] AllToolNames =
+            ToolSchemaBuilder.BuildAll().Select(tool => tool.name).Where(name => !string.IsNullOrEmpty(name)).ToArray();
+
+        private static readonly string[] NothingInstalled = new string[0];
+
+        [Test]
+        public void EveryAddressableToolIsLockedWhenThePackageIsAbsent()
+        {
+            var missing = ToolPackageGate.Compute(AllToolNames, NothingInstalled);
+
+            var addressableTools = AllToolNames.Where(name => name.Contains("addressable")).ToArray();
+            Assert.IsNotEmpty(addressableTools, "the Addressable provider should register tools either way");
+
+            foreach (var tool in addressableTools)
+                Assert.AreEqual("com.unity.addressables", Required(missing, tool), tool);
+        }
+
+        [Test]
+        public void NothingIsLockedOnceThePackageIsInstalled()
+        {
+            var installed = new[] { "com.unity.addressables", "com.unity.render-pipelines.universal" };
+            var missing = ToolPackageGate.Compute(AllToolNames, installed);
+
+            Assert.IsEmpty(missing.Keys.Where(tool => tool.Contains("addressable") || tool.Contains("volume")));
+        }
+
+        // The Memory Profiler provider is mostly built-in: only the calls that go through the
+        // package's crawler or window carry the requirement, so the gate has to read it per method.
+        [Test]
+        public void OnlyThePackageBoundMemoryToolsAreLocked()
+        {
+            var missing = ToolPackageGate.Compute(AllToolNames, NothingInstalled);
+
+            Assert.AreEqual("com.unity.memoryprofiler", Required(missing, "memory_query_top_objects"));
+            Assert.AreEqual("com.unity.memoryprofiler", Required(missing, "memory_query_references"));
+            Assert.AreEqual("com.unity.memoryprofiler", Required(missing, "memory_open_snapshot_in_profiler"));
+
+            Assert.IsFalse(missing.ContainsKey("memory_take_full_snapshot"));
+            Assert.IsFalse(missing.ContainsKey("memory_list_full_snapshots"));
+        }
+
+        [Test]
+        public void AToolWithoutAPackageRequirementIsNeverLocked()
+        {
+            var missing = ToolPackageGate.Compute(AllToolNames, NothingInstalled);
+
+            Assert.IsFalse(missing.ContainsKey("get_hierarchy"));
+            Assert.IsFalse(missing.ContainsKey("get_scene_info"));
+        }
+
+        // Full and Extended are "everything except a niche list", so they are where an unavailable
+        // tool slips back in after the per-tool switches have already been fixed.
+        [TestCase("minimal")]
+        [TestCase("core")]
+        [TestCase("extended")]
+        [TestCase("full")]
+        public void NoProfileDefaultsToAToolThatCannotRun(string profile)
+        {
+            var defaults = MCPToolExportPolicy
+                .DefaultToolsFor(MCPToolExportPolicy.Parse(profile), AllToolNames).ToArray();
+
+            CollectionAssert.IsEmpty(defaults.Where(ToolPackageGate.IsUnavailable).ToArray(),
+                profile + " offers tools whose package is not installed");
+        }
+
+        [Test]
+        public void AProfileSavedBeforeThePackageWentMissingStillCannotExportIt()
+        {
+            var unavailable = AllToolNames.FirstOrDefault(ToolPackageGate.IsUnavailable);
+            if (unavailable == null)
+                Assert.Ignore("every optional package is installed here");
+
+            Assert.IsFalse(MCPToolExportPolicy.IsToolAllowed(
+                unavailable, MCPToolExportPolicy.Parse("full"), profileConfigured: true,
+                profileTools: new[] { unavailable }));
+        }
+
+        private static string Required(IDictionary<string, string> missing, string tool)
+        {
+            Assert.Contains(tool, AllToolNames, tool + " should be registered");
+            return missing.TryGetValue(tool, out var package) ? package : null;
+        }
+    }
+}

--- a/Tests/Editor/ToolExposurePackageGateTests.cs
+++ b/Tests/Editor/ToolExposurePackageGateTests.cs
@@ -1,5 +1,6 @@
 // Copyright (C) KitWright. Licensed under MIT.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using KitWright.Editor.MCP.Server;
@@ -50,8 +51,14 @@ namespace KitWright.Editor.Tests
             Assert.AreEqual("com.unity.memoryprofiler", Required(missing, "memory_query_references"));
             Assert.AreEqual("com.unity.memoryprofiler", Required(missing, "memory_open_snapshot_in_profiler"));
 
-            Assert.IsFalse(missing.ContainsKey("memory_take_full_snapshot"));
-            Assert.IsFalse(missing.ContainsKey("memory_list_full_snapshots"));
+            // Counted rather than named: taking and listing snapshots run on the built-in profiler
+            // API, and ToolTestCoverageTests reads this file for tool names, so spelling one out
+            // here would claim a test that does not exist.
+            var lockedMemoryTools = AllToolNames
+                .Where(name => name.StartsWith("memory_", StringComparison.Ordinal))
+                .Count(missing.ContainsKey);
+
+            Assert.AreEqual(3, lockedMemoryTools, "only the crawler- and window-bound calls need the package");
         }
 
         [Test]

--- a/Tests/Editor/ToolExposurePackageGateTests.cs.meta
+++ b/Tests/Editor/ToolExposurePackageGateTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1ee220fe45e760041acd125ad01e6243


### PR DESCRIPTION
A provider marked `[RequiresPackage]` keeps compiling without its package: its methods answer with a `*_REQUIRED` error so a direct caller gets a hint instead of "unknown tool". Nothing acted on that, so the Full profile exported those tools and Tool Exposure let you switch them on — offering tools that can only fail.

## What changed

`ToolPackageGate` resolves the attribute per tool. A method's own requirement wins over its provider's, so a mostly built-in provider like `MemorySnapshot` locks only the three calls that go through the package's crawler or window, and leaves taking and listing snapshots alone.

Both the export policy and the editor read the gate, so three things now agree:

- a profile default (`DefaultToolsFor`)
- a hand-picked list saved before the package went missing (`IsToolAllowed`)
- the per-tool switches

Locked rows grey out and offer to install the package on click; the install itself is the Integrations card's logic, now shared through `PackageInstaller`.

## What is not gated, and why

| Integration | Why not |
|---|---|
| Test Framework | a hard dependency in `package.json` — always present |
| Input System | its asmdef carries a `defineConstraint`, so the tools vanish with the package |
| Hot Reload | it speeds up tools that work without it |

`director_evaluate` is gated on `com.unity.modules.director`, not on `com.unity.timeline`: it reflects into `PlayableDirector`, which ships with the module. Gating it on the Timeline package would lock a tool that still works in a Playables-only project.

## Verified in the editor

With Addressables and Memory Profiler absent, Select All landed on 287/296 — exactly the 6 Addressable plus 3 Memory tools locked. Installing Addressables from the dialog unlocked its 6 and the count moved to 293/296.

## Also

- "Restore Default" reads as "Reset"
- the outer segments of the profile switch round themselves — `Overflow.Hidden` clips to a rectangle, not to the group's radius

## Tests

8 cases in `ToolExposurePackageGateTests`, including one per profile and one for a profile saved before the package went missing. The memory assertions count rather than name their tools: `ToolTestCoverageTests` reads test sources for tool names, and spelling out `memory_take_full_snapshot` would claim a test that does not exist.

CI: green on 73a1373 (run #91).
