### PR TITLE
fix(ui): render Recent Activity oldest-first

### DIFF
--- a/Editor/UI/RecentActivityPanel.cs
+++ b/Editor/UI/RecentActivityPanel.cs
@@ -270,10 +270,13 @@ namespace KitWright.Editor.MCP.Server
             ClearPreviewTextures();
             _scrollView.contentContainer.Clear();
 
-            foreach (var entry in _server.InteractionLog.GetEntries())
+            // GetEntries is newest-first; the cards read oldest-first so a live append lands at
+            // the bottom, where stick-to-bottom and ScrollToBottom expect the newest one.
+            var entries = _server.InteractionLog.GetEntries();
+            for (int i = entries.Count - 1; i >= 0; i--)
             {
-                if (PassesFilter(entry.Status))
-                    AddRow(entry);
+                if (PassesFilter(entries[i].Status))
+                    AddRow(entries[i]);
             }
 
             RefreshFilterCounts();


### PR DESCRIPTION
@
## Problem

The Recent Activity panel disagreed with itself about ordering.

- `RenderEntries()` walked `InteractionLog.GetEntries()` straight through and appended each card. That method enumerates from `_head - 1` backwards, i.e. **newest-first**, so a rebuild put the newest entry at the **top**.
- `OnEntryAdded()` appends a live entry to the **bottom**.

So after every rebuild (domain reload, filter change) the list flipped, while new entries kept arriving at the bottom. `ScrollToBottom()` and the stick-to-bottom check both assume the newest card is last, so they scrolled to the **oldest** entry.

## Fix

Walk the list backwards in `RenderEntries()` so the cards read oldest-first. That matches the append path and the Unity Console convention users expect.

`GetEntries()` is deliberately left alone: `MCPResourceProvider` reads it too, and newest-first is the right order there.

## Verification

Recompiled clean, then captured the panel: entries now run `03:05:50` (top) to `03:16:13` (bottom), with the scrollbar resting at the bottom on the newest entry.
