### PR TITLE
skills: read Skills~ on every Discover so Rewrite writes the current SKILL.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,7 @@
 - The CodeDom fallback compiler no longer treats mcs's phantom BOM diagnostic (an entry with no error number) as a compilation failure, and its reference list is deduped.
 - The broker is not stopped when a batch-mode editor quits. Our own CI runs `-batchmode -runTests`, so a test run could kill a broker an interactive editor was using.
 - `set_scriptable_object_properties` returns `PROPERTY_SET_FAILED` when no field applied, as `set_component_properties` now does. Both call the same `ComponentSerializer.WriteProperties`, so the loud failure inherited from the deleted `set_component_property` had closed half the hole: a misspelled field name on a `.asset` still came back as `success`, with "asset saved" attached to a write that landed nothing. A partial write is still a success carrying `failCount`, since that one is diagnosable.
+- Configure and Rewrite write the current `Skills~/<id>/SKILL.md`. The package skill catalog was cached for the domain's lifetime on the grounds that a package change forces a reload - but editing a `Skills~` file forces none, since Unity never imports the folder, so a Rewrite after a skill edit wrote the previous body under the previous hash.
 
 ## [1.0.0] - 2026-08-11
 

--- a/Editor/MCP/Server/PackageSkillCatalog.cs
+++ b/Editor/MCP/Server/PackageSkillCatalog.cs
@@ -17,15 +17,11 @@ namespace KitWright.Editor.MCP.Server
     /// </summary>
     internal static class PackageSkillCatalog
     {
-        private static List<ProjectSkillsManager.SkillDefinition> _cache;
-
-        /// <summary>
-        /// Adding or removing a package forces a domain reload, which drops this cache, so a
-        /// domain-lifetime cache cannot go stale behind a package change.
-        /// </summary>
+        // Not cached: Skills~ is invisible to the AssetDatabase, so an edited SKILL.md triggers no
+        // reload, and a domain-lifetime cache kept writing the old body on Rewrite.
         internal static IReadOnlyList<ProjectSkillsManager.SkillDefinition> Discover()
         {
-            return _cache ?? (_cache = Scan());
+            return Scan();
         }
 
         private static List<ProjectSkillsManager.SkillDefinition> Scan()


### PR DESCRIPTION
`PackageSkillCatalog.Discover()` cached its scan for the domain's lifetime. A package add/remove does reload the domain, but editing `Skills~/<id>/SKILL.md` does not (Unity never imports a `~` folder), so after a skill edit Configure/Rewrite wrote the previous body under the previous hash and the Skills tab reported "up to date". Seen today: three Rewrites in a row wrote a stale `match` skill while the file on disk had changed.

Fix: no cache; `Discover()` scans. The panel is UI Toolkit and event-driven, so this is a handful of small file reads per Configure/refresh, not per frame.
